### PR TITLE
Add release build for java

### DIFF
--- a/.github/workflows/java-build-for-release.yml
+++ b/.github/workflows/java-build-for-release.yml
@@ -1,0 +1,92 @@
+name: Build Java Release
+on:
+  push:
+    tags:        
+      # if you change this pattern, make sure jobs.strip-tag still works
+      - 'release/java/v[0-9]+.[0-9]+.[0-9]+'
+jobs:
+  ci:
+    uses: ./.github/workflows/java-build.yml
+
+  strip-tag:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+    steps:
+      - name: process tag 
+        id: version
+        run: |
+          TAG=${{ github.ref_name }}
+          echo "version=${TAG#"release/java/v"}" >> $GITHUB_OUTPUT
+
+  build:
+    runs-on: ubuntu-latest
+    needs: [ci, strip-tag]
+    outputs:
+      hashes: ${{ steps.hash.outputs.hashes }}
+    steps:
+      - name: checkout tag
+        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
+        with:
+          ref: "${{ github.ref }}"
+
+      - name: Set up JDK 8
+        uses: actions/setup-java@de1bb2b0c5634f0fc4438d7aa9944e68f9bf86cc # v3.6.0
+        with:
+          java-version: 8
+          distribution: 'temurin'
+
+      - name: Build project
+        run: |
+          # override the version in gradle.properties
+          cd java
+          ./gradlew clean createReleaseBundle -Pversion=${{ needs.strip-tag.outputs.version }}
+
+      - name: Hash Artifacts
+        id: hash
+        run: |
+          cd java/build/release
+          echo "hashes=$(sha256sum ./* | base64 -w0)" >> $GITHUB_OUTPUT
+          sha256sum ./*
+
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@83fd05a356d7e2593de66fc9913b3002723633cb # v3.1.1
+        with:
+          name: project-release-artifacts
+          path: ./java/build/release/
+          if-no-files-found: error
+
+  provenance:
+    needs: [build, strip-tag]
+    permissions:
+      actions: read # To read the workflow path.
+      id-token: write # To sign the provenance.
+      contents: write
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v1.2.2
+    with:
+      attestation-name: "protobuf-specs-${{ needs.strip-tag.outputs.version }}.attestation.intoto.jsonl"
+      base64-subjects: "${{ needs.build.outputs.hashes }}"
+
+  create-release:
+    runs-on: ubuntu-latest
+    needs: [provenance, build]
+    permissions:
+      contents: write # To draft a release
+    steps:
+      - name: Download attestation
+        uses: actions/download-artifact@9782bd6a9848b53b110e712e20e42d89988822b7 # v3.0.1
+        with:
+          name: "${{ needs.provenance.outputs.attestation-name }}"
+          path: ./release/
+      - name: Download gradle release artifacts
+        uses: actions/download-artifact@9782bd6a9848b53b110e712e20e42d89988822b7 # v3.0.1
+        with:
+          name: project-release-artifacts
+          path: ./release/
+      - name: Create draft release
+        uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844 # v0.1.15
+        with:
+          name: ${{ github.ref_name }}
+          tag_name: ${{ github.ref_name }}
+          files: ./release/*
+          draft: true

--- a/.github/workflows/java-build.yml
+++ b/.github/workflows/java-build.yml
@@ -19,6 +19,7 @@ permissions:
   contents: read
 
 on:
+  workflow_call: # allow this workflow to be called by other workflows
   push:
     paths:
       - '**.proto'

--- a/java/README.md
+++ b/java/README.md
@@ -12,7 +12,10 @@ A jar file will be created at `./build/libs/protobuf-specs-<version>.jar`
 
 ## Releasing
 
-The generate jar can be released to maven central by TODO
+1. On creation of a tag in the style `release/java/v1.2.3`, new artifacts will be built and
+uploaded to a github release `release/java/v1.2.3`
+2. TODO: Explain how a releaser can then complete the release process on their machine by signing
+with pgp and uploading to maven central.
 
 ## Why is the gradle wrapper jar checked in?
 

--- a/java/build.gradle.kts
+++ b/java/build.gradle.kts
@@ -1,5 +1,8 @@
+import org.gradle.api.publish.maven.internal.publication.DefaultMavenPublication
+
 plugins {
     `java-library`
+    `maven-publish`
     id("com.google.protobuf") version "0.9.1"
     id("com.diffplug.spotless") version "6.11.0"
 }
@@ -11,9 +14,6 @@ sourceSets {
         }
     }
 }
-
-group = "dev.sigstore"
-version = "0.1.0"
 
 repositories {
     mavenCentral()
@@ -27,6 +27,11 @@ dependencies {
 tasks.withType<AbstractArchiveTask>().configureEach {
     isPreserveFileTimestamps = false
     isReproducibleFileOrder = true
+}
+
+java {
+    withJavadocJar()
+    withSourcesJar()
 }
 
 protobuf {
@@ -48,4 +53,78 @@ spotless {
         endWithNewline()
     }
     // we have no non-generated java code
+}
+
+val repoUrl = "https://github.com/sigstore/protobuf-specs"
+
+publishing {
+    publications {
+        create<MavenPublication>("mavenJava") {
+
+            artifactId = project.name
+            from(components["java"])
+
+            versionMapping {
+                usage(Usage.JAVA_RUNTIME) {
+                    fromResolutionResult()
+                }
+                usage(Usage.JAVA_API) {
+                    fromResolutionOf("runtimeClasspath")
+                }
+            }
+            pom {
+                name.set(
+                    (project.findProperty("artifact.name") as? String)
+                        ?: project.name
+                )
+                description.set(
+                    project.provider { project.description }
+                )
+                inceptionYear.set("2022")
+                url.set(repoUrl)
+                organization {
+                    name.set("Sigstore")
+                    url.set("https://sigstore.dev")
+                }
+                developers {
+                    developer {
+                        organization.set("Sigstore authors")
+                        organizationUrl.set("https://sigstore.dev")
+                    }
+                }
+                issueManagement {
+                    system.set("GitHub Issues")
+                    url.set("$repoUrl/issues")
+                }
+                licenses {
+                    license {
+                        name.set("Apache-2.0")
+                        url.set("https://www.apache.org/licenses/LICENSE-2.0.txt")
+                    }
+                }
+                scm {
+                    connection.set("scm:git:$repoUrl.git")
+                    developerConnection.set("scm:git:$repoUrl.git")
+                    url.set(repoUrl)
+                    tag.set("HEAD")
+                }
+            }
+        }
+    }
+}
+
+// this task should be used by github actions to create release artifacts along with a slsa
+// attestation.
+tasks.register("createReleaseBundle") {
+    val releaseDir = layout.buildDirectory.dir("release")
+    outputs.dir(releaseDir)
+    dependsOn((publishing.publications["mavenJava"] as DefaultMavenPublication).publishableArtifacts)
+    doLast {
+        project.copy {
+            from((publishing.publications["mavenJava"] as DefaultMavenPublication).publishableArtifacts.files)
+            into(releaseDir)
+            rename("pom-default.xml", "${project.name}-${project.version}.pom")
+            rename("module.json", "${project.name}-${project.version}.module")
+        }
+    }
 }

--- a/java/gradle.properties
+++ b/java/gradle.properties
@@ -1,0 +1,2 @@
+group=dev.sigstore
+version=SNAPSHOT


### PR DESCRIPTION
Triggers release builds (not releases to maven central) of java artifacts when a new tag with format `release/java/v1.2.3` is created. A corresponding github release is generated with jar artifacts AND slsa attestation. ex: https://github.com/loosebazooka/protobuf-specs/releases/tag/untagged-019d132496fa307dce96

TODO: follow up with script to release these artifacts to maven central.

fyi: @woodruffw @znewman01 