### PR TITLE
pb-python: 0.0.1a2

### DIFF
--- a/gen/pb-python/pyproject.toml
+++ b/gen/pb-python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "flit_core.buildapi"
 
 [project]
 name = "sigstore-protobuf-specs"
-version = "0.0.1a1"
+version = "0.0.1a2"
 description = "A library for serializing and deserializing Sigstore messages"
 readme = "README.md"
 license = { file = "LICENSE" }


### PR DESCRIPTION
This is just to push another alpha out the door for testing; one of the maintainers will need to tag `release/python/0.0.1a2` after this is merged.

Signed-off-by: William Woodruff <william@trailofbits.com>
