### PR TITLE
protos: disambiguate `canonicalized_body`

### DIFF
--- a/gen/pb-go/rekor/v1/sigstore_rekor.pb.go
+++ b/gen/pb-go/rekor/v1/sigstore_rekor.pb.go
@@ -327,12 +327,19 @@ type TransparencyLogEntry struct {
 	// entry was appended to the log, and that the log has not been
 	// altered.
 	InclusionProof *InclusionProof `protobuf:"bytes,6,opt,name=inclusion_proof,json=inclusionProof,proto3" json:"inclusion_proof,omitempty"`
-	// The canonicalized Rekor entry body, used for SET verification. This
-	// is the same as the body returned by Rekor. It's included here for
-	// cases where the client cannot deterministically reconstruct the
-	// bundle from the other fields. Clients MUST verify that the signature
-	// referenced in the canonicalized_body matches the signature provided
-	// in the bundle content.
+	// The canonicalized transparency log entry, used to reconstruct
+	// the Signed Entry Timestamp (SET) during verification.
+	// The contents of this field as the same as the `body` field in
+	// a Rekor response, meaning that it does **not** include the "full"
+	// canonicalized form (of log index, ID, etc.) which are
+	// exposed as separate fields. The verifier is responsible for
+	// combining the `canonicalized_body`, `log_index`, `log_id`,
+	// and `integrated_time` into the payload that the SET's signature
+	// is generated over.
+	//
+	// Clients MUST verify that the signatured referenced in the
+	// `canonicalized_body` matches the signature provided in the
+	// `Bundle.content`.
 	CanonicalizedBody []byte `protobuf:"bytes,7,opt,name=canonicalized_body,json=canonicalizedBody,proto3" json:"canonicalized_body,omitempty"`
 }
 

--- a/gen/pb-go/rekor/v1/sigstore_rekor.pb.go
+++ b/gen/pb-go/rekor/v1/sigstore_rekor.pb.go
@@ -329,7 +329,7 @@ type TransparencyLogEntry struct {
 	InclusionProof *InclusionProof `protobuf:"bytes,6,opt,name=inclusion_proof,json=inclusionProof,proto3" json:"inclusion_proof,omitempty"`
 	// The canonicalized transparency log entry, used to reconstruct
 	// the Signed Entry Timestamp (SET) during verification.
-	// The contents of this field as the same as the `body` field in
+	// The contents of this field are the same as the `body` field in
 	// a Rekor response, meaning that it does **not** include the "full"
 	// canonicalized form (of log index, ID, etc.) which are
 	// exposed as separate fields. The verifier is responsible for

--- a/gen/pb-python/sigstore_protobuf_specs/dev/sigstore/rekor/v1/__init__.py
+++ b/gen/pb-python/sigstore_protobuf_specs/dev/sigstore/rekor/v1/__init__.py
@@ -132,7 +132,7 @@ class TransparencyLogEntry(betterproto.Message):
     canonicalized_body: bytes = betterproto.bytes_field(7)
     """
     The canonicalized transparency log entry, used to reconstruct the Signed
-    Entry Timestamp (SET) during verification. The contents of this field as
+    Entry Timestamp (SET) during verification. The contents of this field are
     the same as the `body` field in a Rekor response, meaning that it does
     **not** include the "full" canonicalized form (of log index, ID, etc.)
     which are exposed as separate fields. The verifier is responsible for

--- a/gen/pb-python/sigstore_protobuf_specs/dev/sigstore/rekor/v1/__init__.py
+++ b/gen/pb-python/sigstore_protobuf_specs/dev/sigstore/rekor/v1/__init__.py
@@ -131,9 +131,14 @@ class TransparencyLogEntry(betterproto.Message):
 
     canonicalized_body: bytes = betterproto.bytes_field(7)
     """
-    The canonicalized Rekor entry body, used for SET verification. This is the
-    same as the body returned by Rekor. It's included here for cases where the
-    client cannot deterministically reconstruct the bundle from the other
-    fields. Clients MUST verify that the signature referenced in the
-    canonicalized_body matches the signature provided in the bundle content.
+    The canonicalized transparency log entry, used to reconstruct the Signed
+    Entry Timestamp (SET) during verification. The contents of this field as
+    the same as the `body` field in a Rekor response, meaning that it does
+    **not** include the "full" canonicalized form (of log index, ID, etc.)
+    which are exposed as separate fields. The verifier is responsible for
+    combining the `canonicalized_body`, `log_index`, `log_id`, and
+    `integrated_time` into the payload that the SET's signature is generated
+    over. Clients MUST verify that the signatured referenced in the
+    `canonicalized_body` matches the signature provided in the
+    `Bundle.content`.
     """

--- a/protos/sigstore_rekor.proto
+++ b/protos/sigstore_rekor.proto
@@ -103,11 +103,18 @@ message TransparencyLogEntry {
         // entry was appended to the log, and that the log has not been
         // altered.
         InclusionProof inclusion_proof = 6;
-        // The canonicalized Rekor entry body, used for SET verification. This
-        // is the same as the body returned by Rekor. It's included here for
-        // cases where the client cannot deterministically reconstruct the
-        // bundle from the other fields. Clients MUST verify that the signature
-        // referenced in the canonicalized_body matches the signature provided
-        // in the bundle content.
+        // The canonicalized transparency log entry, used to reconstruct
+        // the Signed Entry Timestamp (SET) during verification.
+        // The contents of this field as the same as the `body` field in
+        // a Rekor response, meaning that it does **not** include the "full"
+        // canonicalized form (of log index, ID, etc.) which are
+        // exposed as separate fields. The verifier is responsible for
+        // combining the `canonicalized_body`, `log_index`, `log_id`,
+        // and `integrated_time` into the payload that the SET's signature
+        // is generated over.
+        //
+        // Clients MUST verify that the signatured referenced in the
+        // `canonicalized_body` matches the signature provided in the
+        // `Bundle.content`.
         bytes canonicalized_body = 7;
 }

--- a/protos/sigstore_rekor.proto
+++ b/protos/sigstore_rekor.proto
@@ -105,7 +105,7 @@ message TransparencyLogEntry {
         InclusionProof inclusion_proof = 6;
         // The canonicalized transparency log entry, used to reconstruct
         // the Signed Entry Timestamp (SET) during verification.
-        // The contents of this field as the same as the `body` field in
+        // The contents of this field are the same as the `body` field in
         // a Rekor response, meaning that it does **not** include the "full"
         // canonicalized form (of log index, ID, etc.) which are
         // exposed as separate fields. The verifier is responsible for


### PR DESCRIPTION
Closes #62.

Let me know if this is too verbose 😅 

Signed-off-by: William Woodruff <william@trailofbits.com>
