### PR TITLE
add missing perms to typescript-publish workflow

### DIFF
--- a/.github/workflows/typescript-publish.yml
+++ b/.github/workflows/typescript-publish.yml
@@ -20,6 +20,10 @@ on:
 
 name: Release TypeScript package
 
+permissions:
+  contents: read
+  id-token: write
+
 jobs:
   publish:
     name: Publish package to npmjs


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
Fix missing GitHub Actions permissions in typescript publishing workflow.

