### PR TITLE
Clarify key ID is a digest over SPKI

### DIFF
--- a/gen/pb-go/common/v1/sigstore_common.pb.go
+++ b/gen/pb-go/common/v1/sigstore_common.pb.go
@@ -348,7 +348,7 @@ type LogId struct {
 	unknownFields protoimpl.UnknownFields
 
 	// The unique id of the log, represented as the SHA-256 hash
-	// of the log's public key, computed over the DER encoding.
+	// of the log's public key, computed over the PKIX encoding.
 	// <https://www.rfc-editor.org/rfc/rfc6962#section-3.2>
 	KeyId []byte `protobuf:"bytes,1,opt,name=key_id,json=keyId,proto3" json:"key_id,omitempty"`
 }

--- a/gen/pb-go/common/v1/sigstore_common.pb.go
+++ b/gen/pb-go/common/v1/sigstore_common.pb.go
@@ -348,8 +348,9 @@ type LogId struct {
 	unknownFields protoimpl.UnknownFields
 
 	// The unique id of the log, represented as the SHA-256 hash
-	// of the log's public key, computed over the PKIX encoding.
-	// <https://www.rfc-editor.org/rfc/rfc6962#section-3.2>
+	// of the log's public key, calculated over the DER encoding
+	// of the key represented as SubjectPublicKeyInfo.
+	// See https://www.rfc-editor.org/rfc/rfc6962#section-3.2
 	KeyId []byte `protobuf:"bytes,1,opt,name=key_id,json=keyId,proto3" json:"key_id,omitempty"`
 }
 

--- a/gen/pb-python/sigstore_protobuf_specs/dev/sigstore/common/v1/__init__.py
+++ b/gen/pb-python/sigstore_protobuf_specs/dev/sigstore/common/v1/__init__.py
@@ -102,7 +102,7 @@ class LogId(betterproto.Message):
     key_id: bytes = betterproto.bytes_field(1)
     """
     The unique id of the log, represented as the SHA-256 hash of the log's
-    public key, computed over the DER encoding. <https://www.rfc-
+    public key, computed over the PKIX encoding. <https://www.rfc-
     editor.org/rfc/rfc6962#section-3.2>
     """
 

--- a/gen/pb-python/sigstore_protobuf_specs/dev/sigstore/common/v1/__init__.py
+++ b/gen/pb-python/sigstore_protobuf_specs/dev/sigstore/common/v1/__init__.py
@@ -102,8 +102,9 @@ class LogId(betterproto.Message):
     key_id: bytes = betterproto.bytes_field(1)
     """
     The unique id of the log, represented as the SHA-256 hash of the log's
-    public key, computed over the PKIX encoding. <https://www.rfc-
-    editor.org/rfc/rfc6962#section-3.2>
+    public key, calculated over the DER encoding of the key represented as
+    SubjectPublicKeyInfo. See https://www.rfc-
+    editor.org/rfc/rfc6962#section-3.2
     """
 
 

--- a/gen/pb-typescript/src/__generated__/sigstore_common.ts
+++ b/gen/pb-typescript/src/__generated__/sigstore_common.ts
@@ -199,7 +199,7 @@ export interface MessageSignature {
 export interface LogId {
   /**
    * The unique id of the log, represented as the SHA-256 hash
-   * of the log's public key, computed over the DER encoding.
+   * of the log's public key, computed over the PKIX encoding.
    * <https://www.rfc-editor.org/rfc/rfc6962#section-3.2>
    */
   keyId: Buffer;

--- a/gen/pb-typescript/src/__generated__/sigstore_common.ts
+++ b/gen/pb-typescript/src/__generated__/sigstore_common.ts
@@ -199,8 +199,9 @@ export interface MessageSignature {
 export interface LogId {
   /**
    * The unique id of the log, represented as the SHA-256 hash
-   * of the log's public key, computed over the PKIX encoding.
-   * <https://www.rfc-editor.org/rfc/rfc6962#section-3.2>
+   * of the log's public key, calculated over the DER encoding
+   * of the key represented as SubjectPublicKeyInfo.
+   * See https://www.rfc-editor.org/rfc/rfc6962#section-3.2
    */
   keyId: Buffer;
 }

--- a/protos/sigstore_common.proto
+++ b/protos/sigstore_common.proto
@@ -85,8 +85,9 @@ message MessageSignature {
 // LogId captures the identity of a transparency log.
 message LogId {
         // The unique id of the log, represented as the SHA-256 hash
-        // of the log's public key, computed over the PKIX encoding.
-        // <https://www.rfc-editor.org/rfc/rfc6962#section-3.2>
+        // of the log's public key, calculated over the DER encoding
+        // of the key represented as SubjectPublicKeyInfo.
+        // See https://www.rfc-editor.org/rfc/rfc6962#section-3.2
         bytes key_id = 1 [(google.api.field_behavior) = REQUIRED];
 }
 

--- a/protos/sigstore_common.proto
+++ b/protos/sigstore_common.proto
@@ -85,7 +85,7 @@ message MessageSignature {
 // LogId captures the identity of a transparency log.
 message LogId {
         // The unique id of the log, represented as the SHA-256 hash
-        // of the log's public key, computed over the DER encoding.
+        // of the log's public key, computed over the PKIX encoding.
         // <https://www.rfc-editor.org/rfc/rfc6962#section-3.2>
         bytes key_id = 1 [(google.api.field_behavior) = REQUIRED];
 }


### PR DESCRIPTION
The comment said the DER encoding, which is not what RFC6962 specifies.

We noted in root-signing that trusted_root.json's key IDs were over the DER encoding of the key, rather than the SubjectPublicKeyInfo structure, which is the raw key and an OID.

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->