### PR TITLE
Clarify usage of VerificationLogEntry.canonicalized_body.

### DIFF
--- a/gen/pb-go/rekor/v1/sigstore_rekor.pb.go
+++ b/gen/pb-go/rekor/v1/sigstore_rekor.pb.go
@@ -327,8 +327,8 @@ type TransparencyLogEntry struct {
 	// entry was appended to the log, and that the log has not been
 	// altered.
 	InclusionProof *InclusionProof `protobuf:"bytes,6,opt,name=inclusion_proof,json=inclusionProof,proto3" json:"inclusion_proof,omitempty"`
-	// The canonicalized transparency log entry, used to reconstruct
-	// the Signed Entry Timestamp (SET) during verification.
+	// Optional. The canonicalized transparency log entry, used to
+	// reconstruct the Signed Entry Timestamp (SET) during verification.
 	// The contents of this field are the same as the `body` field in
 	// a Rekor response, meaning that it does **not** include the "full"
 	// canonicalized form (of log index, ID, etc.) which are
@@ -336,10 +336,15 @@ type TransparencyLogEntry struct {
 	// combining the `canonicalized_body`, `log_index`, `log_id`,
 	// and `integrated_time` into the payload that the SET's signature
 	// is generated over.
+	// This field is intended to be used in cases where the SET cannot be
+	// produced determinisitically (e.g. inconsistent JSON field ordering,
+	// differing whitespace, etc).
 	//
-	// Clients MUST verify that the signatured referenced in the
+	// If set, clients MUST verify that the signature referenced in the
 	// `canonicalized_body` matches the signature provided in the
 	// `Bundle.content`.
+	// If not set, clients are responsible for constructing an equivalent
+	// payload from other sources to verify the signature.
 	CanonicalizedBody []byte `protobuf:"bytes,7,opt,name=canonicalized_body,json=canonicalizedBody,proto3" json:"canonicalized_body,omitempty"`
 }
 

--- a/gen/pb-python/sigstore_protobuf_specs/dev/sigstore/rekor/v1/__init__.py
+++ b/gen/pb-python/sigstore_protobuf_specs/dev/sigstore/rekor/v1/__init__.py
@@ -131,14 +131,17 @@ class TransparencyLogEntry(betterproto.Message):
 
     canonicalized_body: bytes = betterproto.bytes_field(7)
     """
-    The canonicalized transparency log entry, used to reconstruct the Signed
-    Entry Timestamp (SET) during verification. The contents of this field are
-    the same as the `body` field in a Rekor response, meaning that it does
-    **not** include the "full" canonicalized form (of log index, ID, etc.)
+    Optional. The canonicalized transparency log entry, used to reconstruct the
+    Signed Entry Timestamp (SET) during verification. The contents of this
+    field are the same as the `body` field in a Rekor response, meaning that it
+    does **not** include the "full" canonicalized form (of log index, ID, etc.)
     which are exposed as separate fields. The verifier is responsible for
     combining the `canonicalized_body`, `log_index`, `log_id`, and
     `integrated_time` into the payload that the SET's signature is generated
-    over. Clients MUST verify that the signatured referenced in the
-    `canonicalized_body` matches the signature provided in the
-    `Bundle.content`.
+    over. This field is intended to be used in cases where the SET cannot be
+    produced determinisitically (e.g. inconsistent JSON field ordering,
+    differing whitespace, etc). If set, clients MUST verify that the signature
+    referenced in the `canonicalized_body` matches the signature provided in
+    the `Bundle.content`. If not set, clients are responsible for constructing
+    an equivalent payload from other sources to verify the signature.
     """

--- a/gen/pb-typescript/src/__generated__/sigstore_rekor.ts
+++ b/gen/pb-typescript/src/__generated__/sigstore_rekor.ts
@@ -111,8 +111,8 @@ export interface TransparencyLogEntry {
     | InclusionProof
     | undefined;
   /**
-   * The canonicalized transparency log entry, used to reconstruct
-   * the Signed Entry Timestamp (SET) during verification.
+   * Optional. The canonicalized transparency log entry, used to
+   * reconstruct the Signed Entry Timestamp (SET) during verification.
    * The contents of this field are the same as the `body` field in
    * a Rekor response, meaning that it does **not** include the "full"
    * canonicalized form (of log index, ID, etc.) which are
@@ -120,10 +120,15 @@ export interface TransparencyLogEntry {
    * combining the `canonicalized_body`, `log_index`, `log_id`,
    * and `integrated_time` into the payload that the SET's signature
    * is generated over.
+   * This field is intended to be used in cases where the SET cannot be
+   * produced determinisitically (e.g. inconsistent JSON field ordering,
+   * differing whitespace, etc).
    *
-   * Clients MUST verify that the signatured referenced in the
+   * If set, clients MUST verify that the signature referenced in the
    * `canonicalized_body` matches the signature provided in the
    * `Bundle.content`.
+   * If not set, clients are responsible for constructing an equivalent
+   * payload from other sources to verify the signature.
    */
   canonicalizedBody: Buffer;
 }

--- a/protos/sigstore_rekor.proto
+++ b/protos/sigstore_rekor.proto
@@ -103,8 +103,8 @@ message TransparencyLogEntry {
         // entry was appended to the log, and that the log has not been
         // altered.
         InclusionProof inclusion_proof = 6;
-        // The canonicalized transparency log entry, used to reconstruct
-        // the Signed Entry Timestamp (SET) during verification.
+        // Optional. The canonicalized transparency log entry, used to
+        // reconstruct the Signed Entry Timestamp (SET) during verification.
         // The contents of this field are the same as the `body` field in
         // a Rekor response, meaning that it does **not** include the "full"
         // canonicalized form (of log index, ID, etc.) which are
@@ -112,9 +112,14 @@ message TransparencyLogEntry {
         // combining the `canonicalized_body`, `log_index`, `log_id`,
         // and `integrated_time` into the payload that the SET's signature
         // is generated over.
+        // This field is intended to be used in cases where the SET cannot be
+        // produced determinisitically (e.g. inconsistent JSON field ordering,
+        // differing whitespace, etc).
         //
-        // Clients MUST verify that the signatured referenced in the
+        // If set, clients MUST verify that the signature referenced in the
         // `canonicalized_body` matches the signature provided in the
         // `Bundle.content`.
+        // If not set, clients are responsible for constructing an equivalent
+        // payload from other sources to verify the signature.
         bytes canonicalized_body = 7;
 }


### PR DESCRIPTION

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

This updates the doc comment of canonicalized_body to make it clear that it is an optional field, and provides more details on when the field should be set / when it can be safely omitted.

This is not intended to be a change in behavior - this is just clarifying existing intent of the field. 

Fixes https://github.com/sigstore/protobuf-specs/issues/72

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

- Updated the description of VerificationLogEntry.canonicalized_body to clarify when it should be set / when it can be safely omitted.

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->

If there's anything else I need to do besides `make all`, let me know!