### PR TITLE
gen, protos: tweak envelope docs

### DIFF
--- a/gen/pb-go/dsse/envelope.pb.go
+++ b/gen/pb-go/dsse/envelope.pb.go
@@ -47,9 +47,9 @@ type Envelope struct {
 	// REQUIRED.
 	PayloadType string `protobuf:"bytes,2,opt,name=payloadType,proto3" json:"payloadType,omitempty"`
 	// Signature over:
-	//     PAE(type, body)
+	//     PAE(type, payload)
 	// Where PAE is defined as:
-	// PAE(type, body) = "DSSEv1" + SP + LEN(type) + SP + type + SP + LEN(body) + SP + body
+	// PAE(type, payload) = "DSSEv1" + SP + LEN(type) + SP + type + SP + LEN(payload) + SP + payload
 	// +               = concatenation
 	// SP              = ASCII space [0x20]
 	// "DSSEv1"        = ASCII [0x44, 0x53, 0x53, 0x45, 0x76, 0x31]

--- a/gen/pb-python/sigstore_protobuf_specs/io/intoto/__init__.py
+++ b/gen/pb-python/sigstore_protobuf_specs/io/intoto/__init__.py
@@ -21,10 +21,10 @@ class Envelope(betterproto.Message):
 
     signatures: List["Signature"] = betterproto.message_field(3)
     """
-    Signature over:     PAE(type, body) Where PAE is defined as: PAE(type,
-    body) = "DSSEv1" + SP + LEN(type) + SP + type + SP + LEN(body) + SP + body
-    +               = concatenation SP              = ASCII space [0x20]
-    "DSSEv1"        = ASCII [0x44, 0x53, 0x53, 0x45, 0x76, 0x31] LEN(s)
+    Signature over:     PAE(type, payload) Where PAE is defined as: PAE(type,
+    payload) = "DSSEv1" + SP + LEN(type) + SP + type + SP + LEN(payload) + SP +
+    payload +               = concatenation SP              = ASCII space
+    [0x20] "DSSEv1"        = ASCII [0x44, 0x53, 0x53, 0x45, 0x76, 0x31] LEN(s)
     = ASCII decimal encoding of the byte length of s, with no leading zeros
     REQUIRED (length >= 1).
     """

--- a/gen/pb-typescript/src/__generated__/envelope.ts
+++ b/gen/pb-typescript/src/__generated__/envelope.ts
@@ -14,9 +14,9 @@ export interface Envelope {
   payloadType: string;
   /**
    * Signature over:
-   *     PAE(type, body)
+   *     PAE(type, payload)
    * Where PAE is defined as:
-   * PAE(type, body) = "DSSEv1" + SP + LEN(type) + SP + type + SP + LEN(body) + SP + body
+   * PAE(type, payload) = "DSSEv1" + SP + LEN(type) + SP + type + SP + LEN(payload) + SP + payload
    * +               = concatenation
    * SP              = ASCII space [0x20]
    * "DSSEv1"        = ASCII [0x44, 0x53, 0x53, 0x45, 0x76, 0x31]

--- a/protos/envelope.proto
+++ b/protos/envelope.proto
@@ -29,9 +29,9 @@ message Envelope {
   string payloadType = 2;
 
   // Signature over:
-  //     PAE(type, body)
+  //     PAE(type, payload)
   // Where PAE is defined as:
-  // PAE(type, body) = "DSSEv1" + SP + LEN(type) + SP + type + SP + LEN(body) + SP + body
+  // PAE(type, payload) = "DSSEv1" + SP + LEN(type) + SP + type + SP + LEN(payload) + SP + payload
   // +               = concatenation
   // SP              = ASCII space [0x20]
   // "DSSEv1"        = ASCII [0x44, 0x53, 0x53, 0x45, 0x76, 0x31]


### PR DESCRIPTION
This just renames `body` in the DSSE envelope docs to reflect the actual field name, which is `payload`.

CC @znewman01 @kommendorkapten 