### PR TITLE
workflows: add rust-release

### DIFF
--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -1,0 +1,36 @@
+#
+# Copyright 2023 The Sigstore Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+on:
+  push:
+    tags:
+      - 'release/rust/v*'
+
+name: release Rust crate
+
+jobs:
+  publish:
+    name: Publish to crates.io
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: gen/pb-rust
+
+    steps:
+    - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+
+    - run: cargo publish
+      env:
+        CARGO_REGISTRY_TOKEN: "${{ secrets.CARGO_REGISTRY_TOKEN }}"

--- a/gen/pb-rust/Cargo.toml
+++ b/gen/pb-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sigstore_protobuf_specs"
-version = "0.1.0-rc.0"
+version = "0.1.0-rc.1"
 exclude = ["codegen/"]
 authors = ["Sigstore Authors <sigstore-dev@googlegroups.com>"]
 edition = "2021"


### PR DESCRIPTION
Follows #83: this adds a release workflow for the Rust package.

~~Needs administrative action: I can create a `crates.io` token for this, but I'll need a repo owner to add it as a secret.~~