### PR TITLE
Fixed minor spelling errors in a comment.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,6 +65,14 @@ docker-image:
 	@echo "Building development docker image"
 	docker build -t ${PROTOC_IMAGE} .
 
+# to recover from a situation where a stale layer exist, just  purging the
+# docker image via `make clean` is not enough. Re-building without layer
+# cache is the only solution.
+.PHONY: docker-image-no-cache
+docker-image-no-cache:
+	@echo "Building development docker image with disabled cache"
+	docker build --no-cache -t ${PROTOC_IMAGE} .
+
 # clean up generated files (not working? try sudo make clean)
 clean:
 	rm -rf gen/pb-go \

--- a/gen/pb-go/rekor/v1/sigstore_rekor.pb.go
+++ b/gen/pb-go/rekor/v1/sigstore_rekor.pb.go
@@ -166,8 +166,8 @@ type InclusionProof struct {
 	TreeSize int64 `protobuf:"varint,3,opt,name=tree_size,json=treeSize,proto3" json:"tree_size,omitempty"`
 	// A list of hashes required to compute the inclusion proof, sorted
 	// in order from leaf to root.
-	// Not that leaf and root hashes are not included.
-	// The root has is available separately in this message, and the
+	// Note that leaf and root hashes are not included.
+	// The root hash is available separately in this message, and the
 	// leaf hash should be calculated by the client.
 	Hashes [][]byte `protobuf:"bytes,4,rep,name=hashes,proto3" json:"hashes,omitempty"`
 	// Signature of the tree head, as of the time of this proof was

--- a/gen/pb-python/sigstore_protobuf_specs/dev/sigstore/rekor/v1/__init__.py
+++ b/gen/pb-python/sigstore_protobuf_specs/dev/sigstore/rekor/v1/__init__.py
@@ -61,9 +61,9 @@ class InclusionProof(betterproto.Message):
     hashes: List[bytes] = betterproto.bytes_field(4)
     """
     A list of hashes required to compute the inclusion proof, sorted in order
-    from leaf to root. Not that leaf and root hashes are not included. The root
-    has is available separately in this message, and the leaf hash should be
-    calculated by the client.
+    from leaf to root. Note that leaf and root hashes are not included. The
+    root hash is available separately in this message, and the leaf hash should
+    be calculated by the client.
     """
 
     checkpoint: "Checkpoint" = betterproto.message_field(5)

--- a/gen/pb-typescript/src/__generated__/sigstore_rekor.ts
+++ b/gen/pb-typescript/src/__generated__/sigstore_rekor.ts
@@ -43,8 +43,8 @@ export interface InclusionProof {
   /**
    * A list of hashes required to compute the inclusion proof, sorted
    * in order from leaf to root.
-   * Not that leaf and root hashes are not included.
-   * The root has is available separately in this message, and the
+   * Note that leaf and root hashes are not included.
+   * The root hash is available separately in this message, and the
    * leaf hash should be calculated by the client.
    */
   hashes: Buffer[];

--- a/protos/sigstore_rekor.proto
+++ b/protos/sigstore_rekor.proto
@@ -58,8 +58,8 @@ message InclusionProof {
         int64 tree_size = 3 [(google.api.field_behavior) = REQUIRED];
         // A list of hashes required to compute the inclusion proof, sorted
         // in order from leaf to root.
-        // Not that leaf and root hashes are not included.
-        // The root has is available separately in this message, and the
+        // Note that leaf and root hashes are not included.
+        // The root hash is available separately in this message, and the
         // leaf hash should be calculated by the client.
         repeated bytes hashes = 4 [(google.api.field_behavior) = REQUIRED];
         // Signature of the tree head, as of the time of this proof was


### PR DESCRIPTION
#### Summary
Fixed a spelling error in a comment.
Added a new `make(1)` target `docker-image-no-cache` which rebuilds the builder without layer cache.

#### Release Note
N/A

#### Documentation
N/A
