### PR TITLE
Clarify log index in transparency log entry vs inclusion proof

### DIFF
--- a/gen/pb-go/rekor/v1/sigstore_rekor.pb.go
+++ b/gen/pb-go/rekor/v1/sigstore_rekor.pb.go
@@ -312,7 +312,7 @@ type TransparencyLogEntry struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	// The index of the entry in the global log.
+	// The global index of the entry, used when querying the log by index.
 	LogIndex int64 `protobuf:"varint,1,opt,name=log_index,json=logIndex,proto3" json:"log_index,omitempty"`
 	// The unique identifier of the log.
 	LogId *v1.LogId `protobuf:"bytes,2,opt,name=log_id,json=logId,proto3" json:"log_id,omitempty"`

--- a/gen/pb-go/rekor/v1/sigstore_rekor.pb.go
+++ b/gen/pb-go/rekor/v1/sigstore_rekor.pb.go
@@ -157,7 +157,7 @@ type InclusionProof struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	// The index of the entry in the log.
+	// The index of the entry in the tree it was written to.
 	LogIndex int64 `protobuf:"varint,1,opt,name=log_index,json=logIndex,proto3" json:"log_index,omitempty"`
 	// The hash digest stored at the root of the merkle tree at the time
 	// the proof was generated.
@@ -312,7 +312,7 @@ type TransparencyLogEntry struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	// The index of the entry in the log.
+	// The index of the entry in the global log.
 	LogIndex int64 `protobuf:"varint,1,opt,name=log_index,json=logIndex,proto3" json:"log_index,omitempty"`
 	// The unique identifier of the log.
 	LogId *v1.LogId `protobuf:"bytes,2,opt,name=log_id,json=logId,proto3" json:"log_id,omitempty"`

--- a/gen/pb-python/sigstore_protobuf_specs/dev/sigstore/rekor/v1/__init__.py
+++ b/gen/pb-python/sigstore_protobuf_specs/dev/sigstore/rekor/v1/__init__.py
@@ -105,7 +105,7 @@ class TransparencyLogEntry(betterproto.Message):
     """
 
     log_index: int = betterproto.int64_field(1)
-    """The index of the entry in the global log."""
+    """The global index of the entry, used when querying the log by index."""
 
     log_id: "__common_v1__.LogId" = betterproto.message_field(2)
     """The unique identifier of the log."""

--- a/gen/pb-python/sigstore_protobuf_specs/dev/sigstore/rekor/v1/__init__.py
+++ b/gen/pb-python/sigstore_protobuf_specs/dev/sigstore/rekor/v1/__init__.py
@@ -47,7 +47,7 @@ class InclusionProof(betterproto.Message):
     """
 
     log_index: int = betterproto.int64_field(1)
-    """The index of the entry in the log."""
+    """The index of the entry in the tree it was written to."""
 
     root_hash: bytes = betterproto.bytes_field(2)
     """
@@ -105,7 +105,7 @@ class TransparencyLogEntry(betterproto.Message):
     """
 
     log_index: int = betterproto.int64_field(1)
-    """The index of the entry in the log."""
+    """The index of the entry in the global log."""
 
     log_id: "__common_v1__.LogId" = betterproto.message_field(2)
     """The unique identifier of the log."""

--- a/gen/pb-typescript/src/__generated__/sigstore_rekor.ts
+++ b/gen/pb-typescript/src/__generated__/sigstore_rekor.ts
@@ -31,7 +31,7 @@ export interface Checkpoint {
  * be used for offline or online verification against the log.
  */
 export interface InclusionProof {
-  /** The index of the entry in the log. */
+  /** The index of the entry in the tree it was written to. */
   logIndex: string;
   /**
    * The hash digest stored at the root of the merkle tree at the time
@@ -82,7 +82,7 @@ export interface InclusionPromise {
  * as described here https://www.rfc-editor.org/rfc/rfc6962.html#section-3.2.
  */
 export interface TransparencyLogEntry {
-  /** The index of the entry in the log. */
+  /** The index of the entry in the global log. */
   logIndex: string;
   /** The unique identifier of the log. */
   logId:

--- a/gen/pb-typescript/src/__generated__/sigstore_rekor.ts
+++ b/gen/pb-typescript/src/__generated__/sigstore_rekor.ts
@@ -82,7 +82,7 @@ export interface InclusionPromise {
  * as described here https://www.rfc-editor.org/rfc/rfc6962.html#section-3.2.
  */
 export interface TransparencyLogEntry {
-  /** The index of the entry in the global log. */
+  /** The global index of the entry, used when querying the log by index. */
   logIndex: string;
   /** The unique identifier of the log. */
   logId:

--- a/protos/sigstore_rekor.proto
+++ b/protos/sigstore_rekor.proto
@@ -49,7 +49,7 @@ message Checkpoint {
 // InclusionProof is the proof returned from the transparency log. Can
 // be used for offline or online verification against the log.
 message InclusionProof {
-        // The index of the entry in the log.
+        // The index of the entry in the tree it was written to.
         int64 log_index = 1 [(google.api.field_behavior) = REQUIRED];
         // The hash digest stored at the root of the merkle tree at the time
         // the proof was generated.
@@ -90,7 +90,7 @@ message InclusionPromise {
 // the response from Rekor) is similar to a Signed Certificate Timestamp
 // as described here https://www.rfc-editor.org/rfc/rfc6962.html#section-3.2.
 message TransparencyLogEntry {
-        // The index of the entry in the log.
+        // The index of the entry in the global log.
         int64 log_index = 1 [(google.api.field_behavior) = REQUIRED];
         // The unique identifier of the log.
         dev.sigstore.common.v1.LogId log_id = 2 [(google.api.field_behavior) = REQUIRED];

--- a/protos/sigstore_rekor.proto
+++ b/protos/sigstore_rekor.proto
@@ -90,7 +90,7 @@ message InclusionPromise {
 // the response from Rekor) is similar to a Signed Certificate Timestamp
 // as described here https://www.rfc-editor.org/rfc/rfc6962.html#section-3.2.
 message TransparencyLogEntry {
-        // The index of the entry in the global log.
+        // The global index of the entry, used when querying the log by index.
         int64 log_index = 1 [(google.api.field_behavior) = REQUIRED];
         // The unique identifier of the log.
         dev.sigstore.common.v1.LogId log_id = 2 [(google.api.field_behavior) = REQUIRED];


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->
Differentiating the comments for log_index in TransparencyLogEntry versus in InclusionProof.