### PR TITLE
Clarified the intent of the uri field in the certificate authority

### DIFF
--- a/gen/jsonschema/schemas/CertificateAuthority.schema.json
+++ b/gen/jsonschema/schemas/CertificateAuthority.schema.json
@@ -11,7 +11,7 @@
                 },
                 "uri": {
                     "type": "string",
-                    "description": "The URI at which the CA can be accessed."
+                    "description": "The URI identifies the certificate authority. It is RECOMMENDED that the URI is the base URL for the certificate authority, that can be provided to any SDK/client provided by the certificate authority to interact with the certificate authority."
                 },
                 "certChain": {
                     "$ref": "#/definitions/dev.sigstore.common.v1.X509CertificateChain",

--- a/gen/jsonschema/schemas/Input.schema.json
+++ b/gen/jsonschema/schemas/Input.schema.json
@@ -516,7 +516,7 @@
                 },
                 "uri": {
                     "type": "string",
-                    "description": "The URI at which the CA can be accessed."
+                    "description": "The URI identifies the certificate authority. It is RECOMMENDED that the URI is the base URL for the certificate authority, that can be provided to any SDK/client provided by the certificate authority to interact with the certificate authority."
                 },
                 "certChain": {
                     "$ref": "#/definitions/dev.sigstore.common.v1.X509CertificateChain",

--- a/gen/jsonschema/schemas/TrustedRoot.schema.json
+++ b/gen/jsonschema/schemas/TrustedRoot.schema.json
@@ -179,7 +179,7 @@
                 },
                 "uri": {
                     "type": "string",
-                    "description": "The URI at which the CA can be accessed."
+                    "description": "The URI identifies the certificate authority. It is RECOMMENDED that the URI is the base URL for the certificate authority, that can be provided to any SDK/client provided by the certificate authority to interact with the certificate authority."
                 },
                 "certChain": {
                     "$ref": "#/definitions/dev.sigstore.common.v1.X509CertificateChain",

--- a/gen/pb-go/trustroot/v1/sigstore_trustroot.pb.go
+++ b/gen/pb-go/trustroot/v1/sigstore_trustroot.pb.go
@@ -127,7 +127,12 @@ type CertificateAuthority struct {
 	// The root certificate MUST be self-signed, and so the subject and
 	// issuer are the same.
 	Subject *v1.DistinguishedName `protobuf:"bytes,1,opt,name=subject,proto3" json:"subject,omitempty"`
-	// The URI at which the CA can be accessed.
+	// The URI identifies the certificate authority.
+	//
+	// It is RECOMMENDED that the URI is the base URL for the certificate
+	// authority, that can be provided to any SDK/client provided
+	// by the certificate authority to interact with the certificate
+	// authority.
 	Uri string `protobuf:"bytes,2,opt,name=uri,proto3" json:"uri,omitempty"`
 	// The certificate chain for this CA.
 	CertChain *v1.X509CertificateChain `protobuf:"bytes,3,opt,name=cert_chain,json=certChain,proto3" json:"cert_chain,omitempty"`

--- a/gen/pb-python/sigstore_protobuf_specs/dev/sigstore/trustroot/v1/__init__.py
+++ b/gen/pb-python/sigstore_protobuf_specs/dev/sigstore/trustroot/v1/__init__.py
@@ -48,7 +48,12 @@ class CertificateAuthority(betterproto.Message):
     """
 
     uri: str = betterproto.string_field(2)
-    """The URI at which the CA can be accessed."""
+    """
+    The URI identifies the certificate authority. It is RECOMMENDED that the
+    URI is the base URL for the certificate authority, that can be provided to
+    any SDK/client provided by the certificate authority to interact with the
+    certificate authority.
+    """
 
     cert_chain: "__common_v1__.X509CertificateChain" = betterproto.message_field(3)
     """The certificate chain for this CA."""

--- a/gen/pb-rust/schemas/CertificateAuthority.schema.json
+++ b/gen/pb-rust/schemas/CertificateAuthority.schema.json
@@ -11,7 +11,7 @@
                 },
                 "uri": {
                     "type": "string",
-                    "description": "The URI at which the CA can be accessed."
+                    "description": "The URI identifies the certificate authority. It is RECOMMENDED that the URI is the base URL for the certificate authority, that can be provided to any SDK/client provided by the certificate authority to interact with the certificate authority."
                 },
                 "certChain": {
                     "$ref": "#/definitions/dev.sigstore.common.v1.X509CertificateChain",

--- a/gen/pb-rust/schemas/Input.schema.json
+++ b/gen/pb-rust/schemas/Input.schema.json
@@ -516,7 +516,7 @@
                 },
                 "uri": {
                     "type": "string",
-                    "description": "The URI at which the CA can be accessed."
+                    "description": "The URI identifies the certificate authority. It is RECOMMENDED that the URI is the base URL for the certificate authority, that can be provided to any SDK/client provided by the certificate authority to interact with the certificate authority."
                 },
                 "certChain": {
                     "$ref": "#/definitions/dev.sigstore.common.v1.X509CertificateChain",

--- a/gen/pb-rust/schemas/TrustedRoot.schema.json
+++ b/gen/pb-rust/schemas/TrustedRoot.schema.json
@@ -179,7 +179,7 @@
                 },
                 "uri": {
                     "type": "string",
-                    "description": "The URI at which the CA can be accessed."
+                    "description": "The URI identifies the certificate authority. It is RECOMMENDED that the URI is the base URL for the certificate authority, that can be provided to any SDK/client provided by the certificate authority to interact with the certificate authority."
                 },
                 "certChain": {
                     "$ref": "#/definitions/dev.sigstore.common.v1.X509CertificateChain",

--- a/gen/pb-typescript/src/__generated__/sigstore_trustroot.ts
+++ b/gen/pb-typescript/src/__generated__/sigstore_trustroot.ts
@@ -46,7 +46,14 @@ export interface CertificateAuthority {
   subject:
     | DistinguishedName
     | undefined;
-  /** The URI at which the CA can be accessed. */
+  /**
+   * The URI identifies the certificate authority.
+   *
+   * It is RECOMMENDED that the URI is the base URL for the certificate
+   * authority, that can be provided to any SDK/client provided
+   * by the certificate authority to interact with the certificate
+   * authority.
+   */
   uri: string;
   /** The certificate chain for this CA. */
   certChain:

--- a/protos/sigstore_trustroot.proto
+++ b/protos/sigstore_trustroot.proto
@@ -47,7 +47,12 @@ message CertificateAuthority {
         // The root certificate MUST be self-signed, and so the subject and
         // issuer are the same.
         dev.sigstore.common.v1.DistinguishedName subject = 1;
-        // The URI at which the CA can be accessed.
+        // The URI identifies the certificate authority.
+        //
+        // It is RECOMMENDED that the URI is the base URL for the certificate
+        // authority, that can be provided to any SDK/Clients provided
+        // by the certificate authority to interact with the certificate
+        // authority.
         string uri = 2;
         // The certificate chain for this CA.
         dev.sigstore.common.v1.X509CertificateChain cert_chain = 3;

--- a/protos/sigstore_trustroot.proto
+++ b/protos/sigstore_trustroot.proto
@@ -50,7 +50,7 @@ message CertificateAuthority {
         // The URI identifies the certificate authority.
         //
         // It is RECOMMENDED that the URI is the base URL for the certificate
-        // authority, that can be provided to any SDK/Clients provided
+        // authority, that can be provided to any SDK/client provided
         // by the certificate authority to interact with the certificate
         // authority.
         string uri = 2;


### PR DESCRIPTION
Closes https://github.com/sigstore/protobuf-specs/issues/132

#### Summary
Clarified the intent of the uri field in the certificate authority

#### Release Note
Clarified the `uri` field of the certificate authority message in the trust root.

#### Documentation
N/A
