### PR TITLE
Add definition for Sigstore's DSSE signature extension

### DIFF
--- a/gen/jsonschema/schemas/Bundle.schema.json
+++ b/gen/jsonschema/schemas/Bundle.schema.json
@@ -94,7 +94,7 @@
                 }
             ],
             "title": "Verification Material",
-            "description": "VerificationMaterial captures details on the materials used to verify signatures."
+            "description": "VerificationMaterial captures details on the materials used to verify signatures. This message may be embedded in a DSSE envelope as a signature extension. Specifically, the `ext` field of the extension will expect this message when the signature extension is for Sigstore. This is identified by the `kind` field in the extension, which must be set to application/vnd.dev.sigstore.verificationmaterial;version=0.1 for Sigstore. When used as a DSSE extension, if the `public_key` field is used to indicate the key identifier, it MUST match the `keyid` field of the signature the extension is attached to."
         },
         "dev.sigstore.common.v1.HashOutput": {
             "properties": {

--- a/gen/jsonschema/schemas/Input.schema.json
+++ b/gen/jsonschema/schemas/Input.schema.json
@@ -127,7 +127,7 @@
                 }
             ],
             "title": "Verification Material",
-            "description": "VerificationMaterial captures details on the materials used to verify signatures."
+            "description": "VerificationMaterial captures details on the materials used to verify signatures. This message may be embedded in a DSSE envelope as a signature extension. Specifically, the `ext` field of the extension will expect this message when the signature extension is for Sigstore. This is identified by the `kind` field in the extension, which must be set to application/vnd.dev.sigstore.verificationmaterial;version=0.1 for Sigstore. When used as a DSSE extension, if the `public_key` field is used to indicate the key identifier, it MUST match the `keyid` field of the signature the extension is attached to."
         },
         "dev.sigstore.common.v1.DistinguishedName": {
             "properties": {

--- a/gen/jsonschema/schemas/VerificationMaterial.schema.json
+++ b/gen/jsonschema/schemas/VerificationMaterial.schema.json
@@ -41,7 +41,7 @@
                 }
             ],
             "title": "Verification Material",
-            "description": "VerificationMaterial captures details on the materials used to verify signatures."
+            "description": "VerificationMaterial captures details on the materials used to verify signatures. This message may be embedded in a DSSE envelope as a signature extension. Specifically, the `ext` field of the extension will expect this message when the signature extension is for Sigstore. This is identified by the `kind` field in the extension, which must be set to application/vnd.dev.sigstore.verificationmaterial;version=0.1 for Sigstore. When used as a DSSE extension, if the `public_key` field is used to indicate the key identifier, it MUST match the `keyid` field of the signature the extension is attached to."
         },
         "dev.sigstore.bundle.v1.TimestampVerificationData": {
             "properties": {

--- a/gen/pb-go/bundle/v1/sigstore_bundle.pb.go
+++ b/gen/pb-go/bundle/v1/sigstore_bundle.pb.go
@@ -94,7 +94,14 @@ func (x *TimestampVerificationData) GetRfc3161Timestamps() []*v1.RFC3161SignedTi
 }
 
 // VerificationMaterial captures details on the materials used to verify
-// signatures.
+// signatures. This message may be embedded in a DSSE envelope as a signature
+// extension. Specifically, the `ext` field of the extension will expect this
+// message when the signature extension is for Sigstore. This is identified by
+// the `kind` field in the extension, which must be set to
+// application/vnd.dev.sigstore.verificationmaterial;version=0.1 for Sigstore.
+// When used as a DSSE extension, if the `public_key` field is used to indicate
+// the key identifier, it MUST match the `keyid` field of the signature the
+// extension is attached to.
 type VerificationMaterial struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache

--- a/gen/pb-python/sigstore_protobuf_specs/dev/sigstore/bundle/v1/__init__.py
+++ b/gen/pb-python/sigstore_protobuf_specs/dev/sigstore/bundle/v1/__init__.py
@@ -19,9 +19,9 @@ class TimestampVerificationData(betterproto.Message):
     in the future.
     """
 
-    rfc3161_timestamps: List[
-        "__common_v1__.Rfc3161SignedTimestamp"
-    ] = betterproto.message_field(1)
+    rfc3161_timestamps: List["__common_v1__.Rfc3161SignedTimestamp"] = (
+        betterproto.message_field(1)
+    )
     """
     A list of RFC3161 signed timestamps provided by the user. This can be used
     when the entry has not been stored on a transparency log, or in conjunction
@@ -34,7 +34,14 @@ class TimestampVerificationData(betterproto.Message):
 class VerificationMaterial(betterproto.Message):
     """
     VerificationMaterial captures details on the materials used to verify
-    signatures.
+    signatures. This message may be embedded in a DSSE envelope as a signature
+    extension. Specifically, the `ext` field of the extension will expect this
+    message when the signature extension is for Sigstore. This is identified by
+    the `kind` field in the extension, which must be set to
+    application/vnd.dev.sigstore.verificationmaterial;version=0.1 for Sigstore.
+    When used as a DSSE extension, if the `public_key` field is used to
+    indicate the key identifier, it MUST match the `keyid` field of the
+    signature the extension is attached to.
     """
 
     public_key: "__common_v1__.PublicKeyIdentifier" = betterproto.message_field(

--- a/gen/pb-python/sigstore_protobuf_specs/dev/sigstore/verification/v1/__init__.py
+++ b/gen/pb-python/sigstore_protobuf_specs/dev/sigstore/verification/v1/__init__.py
@@ -61,27 +61,27 @@ class ArtifactVerificationOptions(betterproto.Message):
     application specific.
     """
 
-    tlog_options: Optional[
-        "ArtifactVerificationOptionsTlogOptions"
-    ] = betterproto.message_field(3, optional=True, group="_tlog_options")
+    tlog_options: Optional["ArtifactVerificationOptionsTlogOptions"] = (
+        betterproto.message_field(3, optional=True, group="_tlog_options")
+    )
     """
     Optional options for artifact transparency log verification. If none is
     provided, the default verification options are: Threshold: 1 Online
     verification: false Disable: false
     """
 
-    ctlog_options: Optional[
-        "ArtifactVerificationOptionsCtlogOptions"
-    ] = betterproto.message_field(4, optional=True, group="_ctlog_options")
+    ctlog_options: Optional["ArtifactVerificationOptionsCtlogOptions"] = (
+        betterproto.message_field(4, optional=True, group="_ctlog_options")
+    )
     """
     Optional options for certificate transparency log verification. If none is
     provided, the default verification options are: Threshold: 1 Detached SCT:
     false Disable: false
     """
 
-    tsa_options: Optional[
-        "ArtifactVerificationOptionsTimestampAuthorityOptions"
-    ] = betterproto.message_field(5, optional=True, group="_tsa_options")
+    tsa_options: Optional["ArtifactVerificationOptionsTimestampAuthorityOptions"] = (
+        betterproto.message_field(5, optional=True, group="_tsa_options")
+    )
     """
     Optional options for certificate signed timestamp verification. If none is
     provided, the default verification options are: Threshold: 1 Disable: false

--- a/gen/pb-rust/schemas/Bundle.schema.json
+++ b/gen/pb-rust/schemas/Bundle.schema.json
@@ -94,7 +94,7 @@
                 }
             ],
             "title": "Verification Material",
-            "description": "VerificationMaterial captures details on the materials used to verify signatures."
+            "description": "VerificationMaterial captures details on the materials used to verify signatures. This message may be embedded in a DSSE envelope as a signature extension. Specifically, the `ext` field of the extension will expect this message when the signature extension is for Sigstore. This is identified by the `kind` field in the extension, which must be set to application/vnd.dev.sigstore.verificationmaterial;version=0.1 for Sigstore. When used as a DSSE extension, if the `public_key` field is used to indicate the key identifier, it MUST match the `keyid` field of the signature the extension is attached to."
         },
         "dev.sigstore.common.v1.HashOutput": {
             "properties": {

--- a/gen/pb-rust/schemas/Input.schema.json
+++ b/gen/pb-rust/schemas/Input.schema.json
@@ -127,7 +127,7 @@
                 }
             ],
             "title": "Verification Material",
-            "description": "VerificationMaterial captures details on the materials used to verify signatures."
+            "description": "VerificationMaterial captures details on the materials used to verify signatures. This message may be embedded in a DSSE envelope as a signature extension. Specifically, the `ext` field of the extension will expect this message when the signature extension is for Sigstore. This is identified by the `kind` field in the extension, which must be set to application/vnd.dev.sigstore.verificationmaterial;version=0.1 for Sigstore. When used as a DSSE extension, if the `public_key` field is used to indicate the key identifier, it MUST match the `keyid` field of the signature the extension is attached to."
         },
         "dev.sigstore.common.v1.DistinguishedName": {
             "properties": {

--- a/gen/pb-rust/schemas/VerificationMaterial.schema.json
+++ b/gen/pb-rust/schemas/VerificationMaterial.schema.json
@@ -41,7 +41,7 @@
                 }
             ],
             "title": "Verification Material",
-            "description": "VerificationMaterial captures details on the materials used to verify signatures."
+            "description": "VerificationMaterial captures details on the materials used to verify signatures. This message may be embedded in a DSSE envelope as a signature extension. Specifically, the `ext` field of the extension will expect this message when the signature extension is for Sigstore. This is identified by the `kind` field in the extension, which must be set to application/vnd.dev.sigstore.verificationmaterial;version=0.1 for Sigstore. When used as a DSSE extension, if the `public_key` field is used to indicate the key identifier, it MUST match the `keyid` field of the signature the extension is attached to."
         },
         "dev.sigstore.bundle.v1.TimestampVerificationData": {
             "properties": {

--- a/gen/pb-typescript/src/__generated__/sigstore_bundle.ts
+++ b/gen/pb-typescript/src/__generated__/sigstore_bundle.ts
@@ -21,7 +21,14 @@ export interface TimestampVerificationData {
 
 /**
  * VerificationMaterial captures details on the materials used to verify
- * signatures.
+ * signatures. This message may be embedded in a DSSE envelope as a signature
+ * extension. Specifically, the `ext` field of the extension will expect this
+ * message when the signature extension is for Sigstore. This is identified by
+ * the `kind` field in the extension, which must be set to
+ * application/vnd.dev.sigstore.verificationmaterial;version=0.1 for Sigstore.
+ * When used as a DSSE extension, if the `public_key` field is used to indicate
+ * the key identifier, it MUST match the `keyid` field of the signature the
+ * extension is attached to.
  */
 export interface VerificationMaterial {
   content?:

--- a/protos/sigstore_bundle.proto
+++ b/protos/sigstore_bundle.proto
@@ -48,7 +48,14 @@ message TimestampVerificationData {
 }
 
 // VerificationMaterial captures details on the materials used to verify
-// signatures.
+// signatures. This message may be embedded in a DSSE envelope as a signature
+// extension. Specifically, the `ext` field of the extension will expect this
+// message when the signature extension is for Sigstore. This is identified by
+// the `kind` field in the extension, which must be set to
+// application/vnd.dev.sigstore.verificationmaterial;version=0.1 for Sigstore.
+// When used as a DSSE extension, if the `public_key` field is used to indicate
+// the key identifier, it MUST match the `keyid` field of the signature the
+// extension is attached to.
 message VerificationMaterial {
         oneof content {
                 dev.sigstore.common.v1.PublicKeyIdentifier public_key = 1 [(google.api.field_behavior) = REQUIRED];


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

Addresses https://github.com/sigstore/sig-clients/issues/9

This PR adds a definition for Sigstore's DSSE signature extension. The definition is a subset of the current VerificationMaterials message, omitting the option for a key ID in place of the cert chain. This is because the sigstore signature extension in a DSSE signature must only be used to communicate the intermediate certs and timestamp / tlog info.

https://github.com/secure-systems-lab/dsse/pull/61 introduces extensions to the DSSE specification.

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

Define DSSE signature extension for Sigstore signatures.

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->

None.