### PR TITLE
Clarify key hint

### DIFF
--- a/gen/jsonschema/schemas/Bundle.schema.json
+++ b/gen/jsonschema/schemas/Bundle.schema.json
@@ -11,7 +11,7 @@
                 "verificationMaterial": {
                     "$ref": "#/definitions/dev.sigstore.bundle.v1.VerificationMaterial",
                     "additionalProperties": false,
-                    "description": "When a signer is identified by a X.509 certificate, a verifier MUST verify that the signature was computed at the time the certificate was valid as described in the Sigstore client spec: \"Verification using a Bundle\". \u003chttps://docs.google.com/document/d/1kbhK2qyPPk8SLavHzYSDM8-Ueul9_oxIMVFuWMWKz0E/edit#heading=h.x8bduppe89ln\u003e"
+                    "description": "When a signer is identified by a X.509 certificate, a verifier MUST verify that the signature was computed at the time the certificate was valid as described in the Sigstore client spec: \"Verification using a Bundle\". \u003chttps://docs.google.com/document/d/1kbhK2qyPPk8SLavHzYSDM8-Ueul9_oxIMVFuWMWKz0E/edit#heading=h.x8bduppe89ln\u003e If the verification material contains a public key identifier (key hint) and the `content` is a DSSE envelope, the key hints MUST be exactly the same in the verification material and in the DSSE envelope."
                 },
                 "messageSignature": {
                     "$ref": "#/definitions/dev.sigstore.common.v1.MessageSignature",

--- a/gen/jsonschema/schemas/Input.schema.json
+++ b/gen/jsonschema/schemas/Input.schema.json
@@ -44,7 +44,7 @@
                 "verificationMaterial": {
                     "$ref": "#/definitions/dev.sigstore.bundle.v1.VerificationMaterial",
                     "additionalProperties": false,
-                    "description": "When a signer is identified by a X.509 certificate, a verifier MUST verify that the signature was computed at the time the certificate was valid as described in the Sigstore client spec: \"Verification using a Bundle\". \u003chttps://docs.google.com/document/d/1kbhK2qyPPk8SLavHzYSDM8-Ueul9_oxIMVFuWMWKz0E/edit#heading=h.x8bduppe89ln\u003e"
+                    "description": "When a signer is identified by a X.509 certificate, a verifier MUST verify that the signature was computed at the time the certificate was valid as described in the Sigstore client spec: \"Verification using a Bundle\". \u003chttps://docs.google.com/document/d/1kbhK2qyPPk8SLavHzYSDM8-Ueul9_oxIMVFuWMWKz0E/edit#heading=h.x8bduppe89ln\u003e If the verification material contains a public key identifier (key hint) and the `content` is a DSSE envelope, the key hints MUST be exactly the same in the verification material and in the DSSE envelope."
                 },
                 "messageSignature": {
                     "$ref": "#/definitions/dev.sigstore.common.v1.MessageSignature",

--- a/gen/pb-go/bundle/v1/sigstore_bundle.pb.go
+++ b/gen/pb-go/bundle/v1/sigstore_bundle.pb.go
@@ -215,6 +215,10 @@ type Bundle struct {
 	// was valid as described in the Sigstore client spec: "Verification
 	// using a Bundle".
 	// <https://docs.google.com/document/d/1kbhK2qyPPk8SLavHzYSDM8-Ueul9_oxIMVFuWMWKz0E/edit#heading=h.x8bduppe89ln>
+	// If the verification material contains a public key identifier
+	// (key hint) and the `content` is a DSSE envelope, the key hints
+	// MUST be exactly the same in the verification material and in the
+	// DSSE envelope.
 	VerificationMaterial *VerificationMaterial `protobuf:"bytes,2,opt,name=verification_material,json=verificationMaterial,proto3" json:"verification_material,omitempty"`
 	// Types that are assignable to Content:
 	//

--- a/gen/pb-python/sigstore_protobuf_specs/dev/sigstore/bundle/v1/__init__.py
+++ b/gen/pb-python/sigstore_protobuf_specs/dev/sigstore/bundle/v1/__init__.py
@@ -78,7 +78,10 @@ class Bundle(betterproto.Message):
     that the signature was computed at the time the certificate was valid as
     described in the Sigstore client spec: "Verification using a Bundle". <http
     s://docs.google.com/document/d/1kbhK2qyPPk8SLavHzYSDM8-Ueul9_oxIMVFuWMWKz0E
-    /edit#heading=h.x8bduppe89ln>
+    /edit#heading=h.x8bduppe89ln> If the verification material contains a
+    public key identifier (key hint) and the `content` is a DSSE envelope, the
+    key hints MUST be exactly the same in the verification material and in the
+    DSSE envelope.
     """
 
     message_signature: "__common_v1__.MessageSignature" = betterproto.message_field(

--- a/gen/pb-rust/schemas/Bundle.schema.json
+++ b/gen/pb-rust/schemas/Bundle.schema.json
@@ -11,7 +11,7 @@
                 "verificationMaterial": {
                     "$ref": "#/definitions/dev.sigstore.bundle.v1.VerificationMaterial",
                     "additionalProperties": false,
-                    "description": "When a signer is identified by a X.509 certificate, a verifier MUST verify that the signature was computed at the time the certificate was valid as described in the Sigstore client spec: \"Verification using a Bundle\". \u003chttps://docs.google.com/document/d/1kbhK2qyPPk8SLavHzYSDM8-Ueul9_oxIMVFuWMWKz0E/edit#heading=h.x8bduppe89ln\u003e"
+                    "description": "When a signer is identified by a X.509 certificate, a verifier MUST verify that the signature was computed at the time the certificate was valid as described in the Sigstore client spec: \"Verification using a Bundle\". \u003chttps://docs.google.com/document/d/1kbhK2qyPPk8SLavHzYSDM8-Ueul9_oxIMVFuWMWKz0E/edit#heading=h.x8bduppe89ln\u003e If the verification material contains a public key identifier (key hint) and the `content` is a DSSE envelope, the key hints MUST be exactly the same in the verification material and in the DSSE envelope."
                 },
                 "messageSignature": {
                     "$ref": "#/definitions/dev.sigstore.common.v1.MessageSignature",

--- a/gen/pb-rust/schemas/Input.schema.json
+++ b/gen/pb-rust/schemas/Input.schema.json
@@ -44,7 +44,7 @@
                 "verificationMaterial": {
                     "$ref": "#/definitions/dev.sigstore.bundle.v1.VerificationMaterial",
                     "additionalProperties": false,
-                    "description": "When a signer is identified by a X.509 certificate, a verifier MUST verify that the signature was computed at the time the certificate was valid as described in the Sigstore client spec: \"Verification using a Bundle\". \u003chttps://docs.google.com/document/d/1kbhK2qyPPk8SLavHzYSDM8-Ueul9_oxIMVFuWMWKz0E/edit#heading=h.x8bduppe89ln\u003e"
+                    "description": "When a signer is identified by a X.509 certificate, a verifier MUST verify that the signature was computed at the time the certificate was valid as described in the Sigstore client spec: \"Verification using a Bundle\". \u003chttps://docs.google.com/document/d/1kbhK2qyPPk8SLavHzYSDM8-Ueul9_oxIMVFuWMWKz0E/edit#heading=h.x8bduppe89ln\u003e If the verification material contains a public key identifier (key hint) and the `content` is a DSSE envelope, the key hints MUST be exactly the same in the verification material and in the DSSE envelope."
                 },
                 "messageSignature": {
                     "$ref": "#/definitions/dev.sigstore.common.v1.MessageSignature",

--- a/gen/pb-typescript/src/__generated__/sigstore_bundle.ts
+++ b/gen/pb-typescript/src/__generated__/sigstore_bundle.ts
@@ -57,6 +57,10 @@ export interface Bundle {
    * was valid as described in the Sigstore client spec: "Verification
    * using a Bundle".
    * <https://docs.google.com/document/d/1kbhK2qyPPk8SLavHzYSDM8-Ueul9_oxIMVFuWMWKz0E/edit#heading=h.x8bduppe89ln>
+   * If the verification material contains a public key identifier
+   * (key hint) and the `content` is a DSSE envelope, the key hints
+   * MUST be exactly the same in the verification material and in the
+   * DSSE envelope.
    */
   verificationMaterial: VerificationMaterial | undefined;
   content?: { $case: "messageSignature"; messageSignature: MessageSignature } | {

--- a/protos/sigstore_bundle.proto
+++ b/protos/sigstore_bundle.proto
@@ -77,6 +77,10 @@ message Bundle {
         // was valid as described in the Sigstore client spec: "Verification
         // using a Bundle".
         // <https://docs.google.com/document/d/1kbhK2qyPPk8SLavHzYSDM8-Ueul9_oxIMVFuWMWKz0E/edit#heading=h.x8bduppe89ln>
+        // If the verification material contains a public key identifier
+        // (key hint) and the `content` is a DSSE envelope, the key hints
+        // MUST be exactly the same in the verification material and in the
+        // DSSE envelope.
         VerificationMaterial verification_material = 2 [(google.api.field_behavior) = REQUIRED];
         oneof content {
                 dev.sigstore.common.v1.MessageSignature message_signature = 3 [(google.api.field_behavior) = REQUIRED];


### PR DESCRIPTION
#### Summary
Clarified how the use of (reduntant) key hint.
Key hint is both specified in the bundle's `verification material` but may also be specified inside the `content` if it'a DSSE envelope. This discussion started in this PR https://github.com/sigstore/protobuf-specs/pull/145

This PR favours simplicity over efficiency; that is; the key hint should be equal and duplicated to simplify any consumption of the bundle, as the value may appear in multiple places. The key hint (if used) is usually a short string so I argue it's not too bad.

#### Release Note
Clarified how to populate the key hint in the bundle, when the content is a DSSE envelope with a key hint too.

#### Documentation
This PR is only documentation.
