### PR TITLE
python: support 3.12, drop 3.7, bump betterproto

### DIFF
--- a/.github/workflows/python-build.yml
+++ b/.github/workflows/python-build.yml
@@ -32,7 +32,7 @@ jobs:
   build:
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
       fail-fast: false
 
     runs-on: ubuntu-latest

--- a/gen/pb-python/pyproject.toml
+++ b/gen/pb-python/pyproject.toml
@@ -26,9 +26,9 @@ classifiers = [
   "Topic :: Security :: Cryptography",
 ]
 dependencies = [
-  "betterproto==2.0.0b5",
+  "betterproto==2.0.0b6",
 ]
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 
 [project.urls]
 Homepage = "https://pypi.org/project/sigstore-protobuf-specs/"


### PR DESCRIPTION
This drops Python 3.7, since sigstore-python doesn't support it.

It adds Python 3.12 to the test matrix and bumps `betterproto` in the process, since the `b6` release avoids the deprecated `pkg_resources` module; see https://github.com/sigstore/sigstore-python/pull/801.