### PR TITLE
python: prep 0.2.2 release

### DIFF
--- a/gen/pb-python/pyproject.toml
+++ b/gen/pb-python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "flit_core.buildapi"
 
 [project]
 name = "sigstore-protobuf-specs"
-version = "0.2.1"
+version = "0.2.2"
 description = "A library for serializing and deserializing Sigstore messages"
 readme = "README.md"
 license = { file = "LICENSE" }


### PR DESCRIPTION
Gets #151 out the door. Once merged, I'll cut the appropriate release tag as well.