### PR TITLE
Prepare for a v0.3.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,11 +15,11 @@ All versions prior to 0.2.0 are untracked.
   which is preferred in `0.3` bundles with the Sigstore PGI ([#191](https://github.com/sigstore/protobuf-specs/pull/191))
 * Added algorithm registry documentation and update `PublicKeyDetails` message
   ([#194](https://github.com/sigstore/protobuf-specs/pull/194), [#212](https://github.com/sigstore/protobuf-specs/pull/212))
-    * Deterministic ECDSA is deprecated
-    * NIST-P384 and NIST-P521 curves added
-    * Existing (and underspecified) RSA key types are deprecated. New
-      RSA keytypes are defined that specifies size of public modulus
-      and hash algorithm. RSA now only supports
+    * Deterministic ECDSA is **deprecated**
+    * NIST-P384 and NIST-P521 curves **added**
+    * Existing (and underspecified) RSA key types are
+      **deprecated**. New RSA keytypes are defined that specifies size
+      of public modulus and hash algorithm. RSA now only supports
       [PKCS#1](https://datatracker.ietf.org/doc/html/rfc8017#section-8.2)
       signature scheme, and PKIX
       ([SubjectPublicKeyInfo](https://datatracker.ietf.org/doc/html/rfc5280#section-4.1))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ All versions prior to 0.2.0 are untracked.
 
 ## [Unreleased]
 
-### 0.3.0
+## 0.3.0
 
 * Options for more generic observer time ([#179](https://github.com/sigstore/protobuf-specs/pull/179))
 * **BREAKING**: `VerificationMaterials.contents` now has an additional `certificate` variant,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ All versions prior to 0.2.0 are untracked.
 * Options for more generic observer time ([#179](https://github.com/sigstore/protobuf-specs/pull/179))
 * **BREAKING**: `VerificationMaterials.contents` now has an additional `certificate` variant,
   which is preferred in `0.3` bundles with the Sigstore PGI ([#191](https://github.com/sigstore/protobuf-specs/pull/191))
-* Added algorithm registry documentation and update `PublicKeyDetails` message
+* Added algorithm registry documentation and updated `PublicKeyDetails` message
   ([#194](https://github.com/sigstore/protobuf-specs/pull/194), [#212](https://github.com/sigstore/protobuf-specs/pull/212))
     * Deterministic ECDSA is **deprecated**
     * NIST-P384 and NIST-P521 curves **added**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,19 +8,23 @@ All versions prior to 0.2.0 are untracked.
 
 ## [Unreleased]
 
-### Added
+### 0.3.0
 
 * Options for more generic observer time ([#179](https://github.com/sigstore/protobuf-specs/pull/179))
 * **BREAKING**: `VerificationMaterials.contents` now has an additional `certificate` variant,
   which is preferred in `0.3` bundles with the Sigstore PGI ([#191](https://github.com/sigstore/protobuf-specs/pull/191))
-* Added algorithm registry documentation and associated new `KnownSignatureAlgorithm` message
-  ([#194](https://github.com/sigstore/protobuf-specs/pull/194))
+* Added algorithm registry documentation and update `PublicKeyDetails` message
+  ([#194](https://github.com/sigstore/protobuf-specs/pull/194), [#212](https://github.com/sigstore/protobuf-specs/pull/212))
+
 
 ### Changed
 
 * Deprecated support for detached SCTs ([#188](https://github.com/sigstore/protobuf-specs/pull/188))
 
 ### Fixed
+
+* Docs: Clarified rotation of verification materials in the trust root
+  ([#210](https://github.com/sigstore/protobuf-specs/pull/210)
 
 ## 0.2.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,15 @@ All versions prior to 0.2.0 are untracked.
   which is preferred in `0.3` bundles with the Sigstore PGI ([#191](https://github.com/sigstore/protobuf-specs/pull/191))
 * Added algorithm registry documentation and update `PublicKeyDetails` message
   ([#194](https://github.com/sigstore/protobuf-specs/pull/194), [#212](https://github.com/sigstore/protobuf-specs/pull/212))
-
+    * Deterministic ECDSA is deprecated
+    * NIST-P384 and NIST-P521 curves added
+    * Existing (and underspecified) RSA key types are deprecated. New
+      RSA keytypes are defined that specifies size of public modulus
+      and hash algorithm. RSA now only supports
+      [PKCS#1](https://datatracker.ietf.org/doc/html/rfc8017#section-8.2)
+      signature scheme, and PKIX
+      ([SubjectPublicKeyInfo](https://datatracker.ietf.org/doc/html/rfc5280#section-4.1))
+      encoding.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ All versions prior to 0.2.0 are untracked.
       signature scheme, and PKIX
       ([SubjectPublicKeyInfo](https://datatracker.ietf.org/doc/html/rfc5280#section-4.1))
       encoding.
+    * Experimental support for
+      [LMS](https://datatracker.ietf.org/doc/html/rfc8554) key types.
 
 ### Changed
 

--- a/gen/pb-python/pyproject.toml
+++ b/gen/pb-python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "flit_core.buildapi"
 
 [project]
 name = "sigstore-protobuf-specs"
-version = "0.3.0rc0"
+version = "0.3.0"
 description = "A library for serializing and deserializing Sigstore messages"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/gen/pb-ruby/lib/sigstore_protobuf_specs/version.rb
+++ b/gen/pb-ruby/lib/sigstore_protobuf_specs/version.rb
@@ -16,6 +16,6 @@
 
 module Dev
   module Sigstore
-    VERSION = '0.2.1'
+    VERSION = '0.3.0'
   end
 end

--- a/gen/pb-rust/Cargo.lock
+++ b/gen/pb-rust/Cargo.lock
@@ -201,7 +201,7 @@ dependencies = [
 
 [[package]]
 name = "sigstore_protobuf_specs"
-version = "0.1.0-rc.2"
+version = "0.3.0"
 dependencies = [
  "pretty_assertions",
  "schemafy",

--- a/gen/pb-rust/Cargo.toml
+++ b/gen/pb-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sigstore_protobuf_specs"
-version = "0.1.0-rc.2"
+version = "0.3.0"
 exclude = ["codegen/"]
 authors = ["Sigstore Authors <sigstore-dev@googlegroups.com>"]
 edition = "2021"

--- a/gen/pb-typescript/package.json
+++ b/gen/pb-typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sigstore/protobuf-specs",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "description": "code-signing for npm packages",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
#### Summary
v0.3.0 release

#### Release Note
See updated CHANGLOG

#### Documentation

Rendered [CHANGELOG](https://github.com/kommendorkapten/protobuf-specs/blob/changelog-v3-b3/CHANGELOG.md)
