### PR TITLE
target node16 for typescript package

### DIFF
--- a/.github/workflows/typescript-build.yml
+++ b/.github/workflows/typescript-build.yml
@@ -33,12 +33,12 @@ jobs:
     strategy:
       matrix:
         node-version:
-          - 14.17.0
-          - 14.x
-          - 16.13.0
+          - 16.14.0
           - 16.x
-          - 18.0.0
+          - 18.17.0
           - 18.x
+          - 20.5.0
+          - 20.x
       fail-fast: false
     runs-on: ubuntu-latest
 

--- a/gen/pb-typescript/package-lock.json
+++ b/gen/pb-typescript/package-lock.json
@@ -1,13 +1,53 @@
 {
   "name": "@sigstore/protobuf-specs",
-  "version": "0.1.0",
-  "lockfileVersion": 1,
+  "version": "0.3.0",
+  "lockfileVersion": 2,
   "requires": true,
+  "packages": {
+    "": {
+      "name": "@sigstore/protobuf-specs",
+      "version": "0.3.0",
+      "license": "Apache-2.0",
+      "devDependencies": {
+        "@tsconfig/node16": "^16.1.1",
+        "@types/node": "^18.14.0",
+        "typescript": "^4.9.5"
+      },
+      "engines": {
+        "node": "^16.14.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@tsconfig/node16": {
+      "version": "16.1.1",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-16.1.1.tgz",
+      "integrity": "sha512-+pio93ejHN4nINX4pXqfnR/fPLRtJBaT4ORaa5RH0Oc1zoYmo2B2koG+M328CQhHKn1Wj6FcOxCDFXAot9NhvA==",
+      "dev": true
+    },
+    "node_modules/@types/node": {
+      "version": "18.14.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.14.0.tgz",
+      "integrity": "sha512-5EWrvLmglK+imbCJY0+INViFWUHg1AHel1sq4ZVSfdcNqGy9Edv3UB9IIzzg+xPaUcAgZYcfVs2fBcwDeZzU0A==",
+      "dev": true
+    },
+    "node_modules/typescript": {
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
+      }
+    }
+  },
   "dependencies": {
-    "@tsconfig/node14": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
-      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+    "@tsconfig/node16": {
+      "version": "16.1.1",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-16.1.1.tgz",
+      "integrity": "sha512-+pio93ejHN4nINX4pXqfnR/fPLRtJBaT4ORaa5RH0Oc1zoYmo2B2koG+M328CQhHKn1Wj6FcOxCDFXAot9NhvA==",
       "dev": true
     },
     "@types/node": {

--- a/gen/pb-typescript/package.json
+++ b/gen/pb-typescript/package.json
@@ -21,11 +21,11 @@
   },
   "homepage": "https://github.com/sigstore/protobuf-specs#readme",
   "devDependencies": {
-    "@tsconfig/node14": "^1.0.3",
+    "@tsconfig/node16": "^16.1.1",
     "@types/node": "^18.14.0",
     "typescript": "^4.9.5"
   },
   "engines": {
-    "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+    "node": "^16.14.0 || >=18.0.0"
   }
 }

--- a/gen/pb-typescript/tsconfig.json
+++ b/gen/pb-typescript/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "declaration": true,
     "noImplicitAny": true,


### PR DESCRIPTION
Updates the typescript package to specify node16 as the oldest supported runtime (node14 is far out of support at this point).

Note: there's no need to cut a new release after merging these changes, we can wait until the next protobuf update.