### PR TITLE
Avoid circular require in generated Ruby code

### DIFF
--- a/gen/pb-ruby/lib/sigstore_protobuf_specs.rb
+++ b/gen/pb-ruby/lib/sigstore_protobuf_specs.rb
@@ -14,5 +14,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-require 'sigstore_protobuf_specs/version'
-Dir[File.join(__dir__, '*.rb')].each { |file| require file }
+require_relative 'sigstore_protobuf_specs/version'
+Dir['*_pb.rb', base: __dir__].each { |file| require_relative file }


### PR DESCRIPTION
By only loading the generated protobuf ruby files and not the "sigstore_protobuf_specs" file

Before:

```sh
$ chruby-exec ruby-2.7 -- ruby -w -rbundler/inline -e 'gemfile { source "https://rubygems.org"; gemspec }; require "sigstore_protobuf_specs"'
/Users/segiddins/.rubies/ruby-2.7.5/lib/ruby/site_ruby/2.7.0/rubygems/core_ext/kernel_require.rb:38: warning: /Users/segiddins/.rubies/ruby-2.7.5/lib/ruby/site_ruby/2.7.0/rubygems/core_ext/kernel_require.rb:38: warning: loading in progress, circular require considered harmful - /Users/segiddins/Development/github.com/sigstore/protobuf-specs/gen/pb-ruby/lib/sigstore_protobuf_specs.rb
        from -e:1:in  `<main>'
        from /Users/segiddins/.rubies/ruby-2.7.5/lib/ruby/site_ruby/2.7.0/bundler/inline.rb:42:in  `gemfile'
        from /Users/segiddins/.rubies/ruby-2.7.5/lib/ruby/site_ruby/2.7.0/bundler.rb:411:in  `with_unbundled_env'
        from /Users/segiddins/.rubies/ruby-2.7.5/lib/ruby/site_ruby/2.7.0/bundler.rb:657:in  `with_env'
        from /Users/segiddins/.rubies/ruby-2.7.5/lib/ruby/site_ruby/2.7.0/bundler.rb:411:in  `block in with_unbundled_env'
        from /Users/segiddins/.rubies/ruby-2.7.5/lib/ruby/site_ruby/2.7.0/bundler/inline.rb:51:in  `block in gemfile'
        from /Users/segiddins/.rubies/ruby-2.7.5/lib/ruby/site_ruby/2.7.0/bundler/settings.rb:130:in  `temporary'
        from /Users/segiddins/.rubies/ruby-2.7.5/lib/ruby/site_ruby/2.7.0/bundler/inline.rb:66:in  `block (2 levels) in gemfile'
        from /Users/segiddins/.rubies/ruby-2.7.5/lib/ruby/site_ruby/2.7.0/bundler/runtime.rb:44:in  `require'
        from /Users/segiddins/.rubies/ruby-2.7.5/lib/ruby/site_ruby/2.7.0/bundler/runtime.rb:44:in  `each'
        from /Users/segiddins/.rubies/ruby-2.7.5/lib/ruby/site_ruby/2.7.0/bundler/runtime.rb:55:in  `block in require'
        from /Users/segiddins/.rubies/ruby-2.7.5/lib/ruby/site_ruby/2.7.0/bundler/runtime.rb:55:in  `each'
        from /Users/segiddins/.rubies/ruby-2.7.5/lib/ruby/site_ruby/2.7.0/bundler/runtime.rb:60:in  `block (2 levels) in require'
        from /Users/segiddins/.rubies/ruby-2.7.5/lib/ruby/site_ruby/2.7.0/bundler/runtime.rb:60:in  `require'
        from /Users/segiddins/Development/github.com/sigstore/protobuf-specs/gen/pb-ruby/lib/sigstore_protobuf_specs.rb:18:in  `<top (required)>'
        from /Users/segiddins/Development/github.com/sigstore/protobuf-specs/gen/pb-ruby/lib/sigstore_protobuf_specs.rb:18:in  `each'
        from /Users/segiddins/Development/github.com/sigstore/protobuf-specs/gen/pb-ruby/lib/sigstore_protobuf_specs.rb:18:in  `block in <top (required)>'
        from /Users/segiddins/.rubies/ruby-2.7.5/lib/ruby/site_ruby/2.7.0/rubygems/core_ext/kernel_require.rb:38:in  `require'
        from /Users/segiddins/.rubies/ruby-2.7.5/lib/ruby/site_ruby/2.7.0/rubygems/core_ext/kernel_require.rb:38:in  `require'
```

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary

Avoid a warning in the generated ruby code

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

Avoid a warning in the generated ruby code

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
