### PR TITLE
Don't run as root when building protobuf files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,15 +6,23 @@ RUN set -ex && \
     apt-get install -y --no-install-recommends \
     python3-pip
 
-# Install Rust cargo.
-RUN set -ex && \
-    apt-get install -y --no-install-recommends \
-        curl \
-        build-essential
-RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | bash -s -- -y
-ENV PATH="/root/.cargo/bin:${PATH}"
-
 # Install Python dev dependencies.
 COPY ./dev-requirements.txt /tmp/
 RUN python3 -m pip install --upgrade pip && \
     python3 -m pip install --requirement /tmp/dev-requirements.txt
+
+# Install Rust cargo.
+RUN set -ex && \
+    apt-get install -y --no-install-recommends \
+        curl \
+    build-essential
+
+# Switch user
+ARG uid=1000
+RUN useradd -u ${uid} -s /bin/sh -m builder
+
+USER builder
+WORKDIR /home/builder
+
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | bash -s -- -y
+ENV PATH="/home/builder/.cargo/bin:${PATH}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN python3 -m pip install --upgrade pip && \
 RUN set -ex && \
     apt-get install -y --no-install-recommends \
         curl \
-    build-essential
+        build-essential
 
 # Switch user
 ARG uid=1000

--- a/Dockerfile.jsonschema
+++ b/Dockerfile.jsonschema
@@ -1,7 +1,19 @@
 # 3.18.2
 FROM alpine@sha256:c5b1261d6d3e43071626931fc004f70149baeba2c8ec672bd4f27761f8e1ad6b
 RUN apk add --update protoc protobuf-dev go git
+
+# Switch user
+ARG uid=1000
+RUN adduser -u ${uid} -S builder
+
+RUN mkdir -p /home/builder
+RUN chown builder /home/builder
+
+USER builder
+WORKDIR /home/builder
+
 RUN go install github.com/chrusty/protoc-gen-jsonschema/cmd/protoc-gen-jsonschema@1.4.1
+
 # This is required to get the field_behavior.proto file
 # NOTE: --filter=tree:0 performs a treeless clone; we do this to optimize cloning
 # this otherwise relatively heavy repository.

--- a/Makefile
+++ b/Makefile
@@ -59,12 +59,12 @@ jsonschema: docker-image-jsonschema
 		${JSONSCHEMA_IMAGE} \
 		-c "cd /defs/gen/jsonschema && ./jsonschema.sh -I ../../protos -I /home/builder/googleapis/ --jsonschema_out=schemas ../../protos/*.proto"
 
-rust: docker-image gen/pb-rust/schemas
+rust: docker-image
 	@echo "Generating rust protobuf files"
 	${DOCKER_RUN} -e "RUST_BACKTRACE=1" \
-		-e "CARGO_REGISTRY_TOKEN"
+		-e "CARGO_REGISTRY_TOKEN" \
 		--entrypoint bash ${PROTOC_IMAGE} \
-		-c "cd /defs/gen/pb-rust && cargo build"
+		-c "cd /defs/gen/pb-rust && cargo ${RUST_ACTION}"
 
 # docker already does its own caching so we can attempt a build every time
 .PHONY: docker-image

--- a/gen/jsonschema/jsonschema.sh
+++ b/gen/jsonschema/jsonschema.sh
@@ -3,7 +3,7 @@
 set -u
 set -e
 
-protoc --plugin=/root/go/bin/protoc-gen-jsonschema \
+protoc --plugin=/home/builder/go/bin/protoc-gen-jsonschema \
        --jsonschema_opt=disallow_additional_properties \
        --jsonschema_opt=enforce_oneof \
        --jsonschema_opt=enums_as_strings_only \


### PR DESCRIPTION
May close https://github.com/sigstore/protobuf-specs/issues/244

#### Summary
Make sure that docker does not run as root when building protobuf files.

#### Release Note
N/A

#### Documentation
N/A
