### PR TITLE
gen: bump patch versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ All versions prior to 0.2.0 are untracked.
 
 ## [Unreleased]
 
+### Added
+
+* Added `TransparencyLogInstance.checkpoint_key_id` as an optional key identifier
+  for logs that generate checkpoints ([#284](https://github.com/sigstore/protobuf-specs/pull/284))
+
+### Changed
+
+* Docs: Clarified DSSE envelope signature cardinality ([#318](https://github.com/sigstore/protobuf-specs/pull/318))
+* Docs: Clarifier behavior of key identifiers ([#284](https://github.com/sigstore/protobuf-specs/pull/284))
+
 ## 0.3.1
 
 * Added client configuration message for signing ([#277](https://github.com/sigstore/protobuf-specs/pull/277))

--- a/gen/pb-python/pyproject.toml
+++ b/gen/pb-python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "flit_core.buildapi"
 
 [project]
 name = "sigstore-protobuf-specs"
-version = "0.3.1"
+version = "0.3.2"
 description = "A library for serializing and deserializing Sigstore messages"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/gen/pb-ruby/lib/sigstore_protobuf_specs/version.rb
+++ b/gen/pb-ruby/lib/sigstore_protobuf_specs/version.rb
@@ -16,6 +16,6 @@
 
 module Dev
   module Sigstore
-    VERSION = '0.3.1'
+    VERSION = '0.3.2'
   end
 end

--- a/gen/pb-rust/Cargo.lock
+++ b/gen/pb-rust/Cargo.lock
@@ -425,7 +425,7 @@ dependencies = [
 
 [[package]]
 name = "sigstore_protobuf_specs"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "anyhow",
  "glob",

--- a/gen/pb-rust/sigstore-protobuf-specs/Cargo.toml
+++ b/gen/pb-rust/sigstore-protobuf-specs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sigstore_protobuf_specs"
-version = "0.3.4"
+version = "0.3.5"
 authors = ["Sigstore Authors <sigstore-dev@googlegroups.com>"]
 edition = "2021"
 homepage = "https://github.com/sigstore/protobuf-specs"


### PR DESCRIPTION
A couple of useful changes have landed since the last patch release, so this bumps the patch versions where relevant 🙂 

