### PR TITLE
rust: bump patch

### DIFF
--- a/gen/pb-rust/Cargo.lock
+++ b/gen/pb-rust/Cargo.lock
@@ -425,7 +425,7 @@ dependencies = [
 
 [[package]]
 name = "sigstore_protobuf_specs"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "anyhow",
  "glob",

--- a/gen/pb-rust/sigstore-protobuf-specs/Cargo.toml
+++ b/gen/pb-rust/sigstore-protobuf-specs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sigstore_protobuf_specs"
-version = "0.3.5"
+version = "0.3.6"
 authors = ["Sigstore Authors <sigstore-dev@googlegroups.com>"]
 edition = "2021"
 homepage = "https://github.com/sigstore/protobuf-specs"


### PR DESCRIPTION
Preps a version for #327.

(As part of this: I propose that the next round of patch releases for all clients "fast-forward" to 0.3.6 so that they're once again consistent with each other. This should be a one-time operation, since we'll use pre-releases more aggressively for build debugging in the future 😅.)