### PR TITLE
update go to 1.21 in go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/sigstore/protobuf-specs
 
-go 1.22
+go 1.22.0
 
 require (
 	google.golang.org/genproto/googleapis/api v0.0.0-20230726155614-23370e0ffb3e

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/sigstore/protobuf-specs
 
-go 1.18
+go 1.21
 
 require (
 	google.golang.org/genproto/googleapis/api v0.0.0-20230726155614-23370e0ffb3e

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/sigstore/protobuf-specs
 
-go 1.21
+go 1.22
 
 require (
 	google.golang.org/genproto/googleapis/api v0.0.0-20230726155614-23370e0ffb3e


### PR DESCRIPTION
PR updates the `go` directive to `go 1.21` from `go 1.18` in `go.mod` file.  Both direct dependencies contain that version in their respective go.mod files:
* https://github.com/googleapis/go-genproto/blob/796eee8c2d537a6e5c8de22908f4facea945ebde/googleapis/api/go.mod#L3
* https://github.com/protocolbuffers/protobuf-go/blob/v1.35.1/go.mod#L3

