### PR TITLE
update typescript package to node18

### DIFF
--- a/.github/workflows/typescript-build.yml
+++ b/.github/workflows/typescript-build.yml
@@ -33,8 +33,6 @@ jobs:
     strategy:
       matrix:
         node-version:
-          - 16.14.0
-          - 16.x
           - 18.17.0
           - 18.x
           - 20.5.0

--- a/.github/workflows/typescript-publish.yml
+++ b/.github/workflows/typescript-publish.yml
@@ -47,7 +47,6 @@ jobs:
         npm run build
     - name: Publish package
       run: |
-        npm install -g npm@latest
         npm publish --provenance --access public
       env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}

--- a/gen/pb-typescript/package-lock.json
+++ b/gen/pb-typescript/package-lock.json
@@ -1,27 +1,28 @@
 {
   "name": "@sigstore/protobuf-specs",
-  "version": "0.3.0",
+  "version": "0.3.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@sigstore/protobuf-specs",
-      "version": "0.3.0",
+      "version": "0.3.3",
       "license": "Apache-2.0",
       "devDependencies": {
-        "@tsconfig/node16": "^16.1.1",
+        "@tsconfig/node18": "^18.2.4",
         "@types/node": "^18.14.0",
-        "typescript": "^4.9.5"
+        "typescript": "^5.7.2"
       },
       "engines": {
-        "node": "^16.14.0 || >=18.0.0"
+        "node": "^18.17.0 || >=20.5.0"
       }
     },
-    "node_modules/@tsconfig/node16": {
-      "version": "16.1.1",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-16.1.1.tgz",
-      "integrity": "sha512-+pio93ejHN4nINX4pXqfnR/fPLRtJBaT4ORaa5RH0Oc1zoYmo2B2koG+M328CQhHKn1Wj6FcOxCDFXAot9NhvA==",
-      "dev": true
+    "node_modules/@tsconfig/node18": {
+      "version": "18.2.4",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node18/-/node18-18.2.4.tgz",
+      "integrity": "sha512-5xxU8vVs9/FNcvm3gE07fPbn9tl6tqGGWA9tSlwsUEkBxtRnTsNmwrV8gasZ9F/EobaSv9+nu8AxUKccw77JpQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/node": {
       "version": "18.14.0",
@@ -30,24 +31,25 @@
       "dev": true
     },
     "node_modules/typescript": {
-      "version": "4.9.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "version": "5.7.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.3.tgz",
+      "integrity": "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==",
       "dev": true,
+      "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=4.2.0"
+        "node": ">=14.17"
       }
     }
   },
   "dependencies": {
-    "@tsconfig/node16": {
-      "version": "16.1.1",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-16.1.1.tgz",
-      "integrity": "sha512-+pio93ejHN4nINX4pXqfnR/fPLRtJBaT4ORaa5RH0Oc1zoYmo2B2koG+M328CQhHKn1Wj6FcOxCDFXAot9NhvA==",
+    "@tsconfig/node18": {
+      "version": "18.2.4",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node18/-/node18-18.2.4.tgz",
+      "integrity": "sha512-5xxU8vVs9/FNcvm3gE07fPbn9tl6tqGGWA9tSlwsUEkBxtRnTsNmwrV8gasZ9F/EobaSv9+nu8AxUKccw77JpQ==",
       "dev": true
     },
     "@types/node": {
@@ -57,9 +59,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "4.9.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "version": "5.7.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.3.tgz",
+      "integrity": "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==",
       "dev": true
     }
   }

--- a/gen/pb-typescript/package.json
+++ b/gen/pb-typescript/package.json
@@ -21,11 +21,11 @@
   },
   "homepage": "https://github.com/sigstore/protobuf-specs#readme",
   "devDependencies": {
-    "@tsconfig/node16": "^16.1.1",
+    "@tsconfig/node18": "^18.2.4",
     "@types/node": "^18.14.0",
-    "typescript": "^4.9.5"
+    "typescript": "^5.7.2"
   },
   "engines": {
-    "node": "^16.14.0 || >=18.0.0"
+    "node": "^18.17.0 || >=20.5.0"
   }
 }

--- a/gen/pb-typescript/tsconfig.json
+++ b/gen/pb-typescript/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node16/tsconfig.json",
+  "extends": "@tsconfig/node18/tsconfig.json",
   "compilerOptions": {
     "declaration": true,
     "noImplicitAny": true,


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
Fixes #464 

Sets the minimum node version to v18.17.x. Updates the `typescript` and `tsconfig` dependencies accordingly.

