### PR TITLE
allow each language to specify protoc, googleapis versions independently

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,11 +31,13 @@ DOCKER_RUN = docker run --platform ${PLATFORM} --user ${UID}:${GID}
 
 PROTOS = $(shell find protos/ -iname "*.proto" | sed 's|^|/defs/|')
 
+include protoc-builder/versions.mk
+
 # generate all language protobuf code
 all: go python typescript ruby jsonschema rust
 
 # generate Go protobuf code
-go: docker-image
+go: base-image-go
 	@echo "Generating go proto Docker image"
 	cd protoc-builder && ${DOCKER_BUILD} -t ${PROTOC_GO_IMAGE} -f Dockerfile.go .
 	@echo "Generating go protobuf files"
@@ -43,7 +45,7 @@ go: docker-image
 	  -I/opt/include -I/googleapis -I/defs/protos \
 	  --go_opt=module=github.com/sigstore/protobuf-specs/gen/pb-go --go_out=/defs/gen/pb-go ${PROTOS}
 
-python: docker-image
+python: base-image-python
 	@echo "Generating python proto Docker image"
 	cd protoc-builder && ${DOCKER_BUILD} -t ${PROTOC_PYTHON_IMAGE} -f Dockerfile.python .
 	@echo "Generating python protobuf files"
@@ -51,7 +53,7 @@ python: docker-image
 	  -I/opt/include -I/googleapis -I/defs/protos \
 	  --python_betterproto_opt=pydantic_dataclasses --python_betterproto_out=/defs/gen/pb-python/sigstore_protobuf_specs ${PROTOS}
 
-typescript: docker-image
+typescript: base-image-typescript
 	@echo "Generating typescript proto Docker image"
 	cd protoc-builder && ${DOCKER_BUILD} -t ${PROTOC_TYPESCRIPT_IMAGE} -f Dockerfile.typescript .
 	@echo "Generating javascript protobuf files"
@@ -59,49 +61,89 @@ typescript: docker-image
 	  -I/opt/include -I/googleapis -I/defs/protos \
 	  --ts_proto_out=/defs/gen/pb-typescript/src/__generated__ --ts_proto_opt=oneof=unions,forceLong=string,env=node,exportCommonSymbols=false,outputPartialMethods=false,outputEncodeMethods=false,unrecognizedEnum=false ${PROTOS}
 
-ruby: docker-image
+ruby: base-image-ruby
 	@echo "Generating ruby proto Docker image"
 	cd protoc-builder && ${DOCKER_BUILD} -t ${PROTOC_RUBY_IMAGE} -f Dockerfile.ruby .
 	@echo "Generating ruby protobuf files"
 	${DOCKER_RUN} -v ${PWD}:/defs ${PROTOC_RUBY_IMAGE} \
 	  -I/opt/include -I/googleapis -I/defs/protos --ruby_out=/defs/gen/pb-ruby/lib ${PROTOS}
 
-jsonschema: docker-image
+jsonschema: base-image-jsonschema
 	@echo "Generating jsonschema proto Docker image"
 	cd protoc-builder && ${DOCKER_BUILD} -t ${PROTOC_JSONSCHEMA_IMAGE} -f Dockerfile.jsonschema .
 	@echo "Generating JSON schema files"
 	mkdir -p gen/jsonschema/schemas
 	${DOCKER_RUN} -v ${PWD}:/defs ${PROTOC_JSONSCHEMA_IMAGE} \
 	  -I/opt/include -I/googleapis -I/defs/protos \
-	  --jsonschema_out=/defs/gen/jsonschema/schemas --jsonschema_opt=disallow_additional_properties --jsonschema_opt=enforce_oneof --jsonschema_opt=enums_as_strings_only --jsonschema_opt=file_extension=schema.json --jsonschema_opt=json_fieldnames \
-      ${PROTOS}
+	  --jsonschema_out=/defs/gen/jsonschema/schemas --jsonschema_opt=disallow_additional_properties --jsonschema_opt=enforce_oneof --jsonschema_opt=enums_as_strings_only --jsonschema_opt=file_extension=schema.json --jsonschema_opt=json_fieldnames ${PROTOS}
 
-rust: docker-image
+rust: base-image-rust
 	@echo "Generating rust proto Docker image"
 	cd protoc-builder && ${DOCKER_BUILD} -t ${PROTOC_RUST_IMAGE} -f Dockerfile.rust .
 	${DOCKER_RUN} -v ${PWD}:/defs \
 	  -e "RUST_BACKTRACE=1" -e "CARGO_REGISTRY_TOKEN" ${PROTOC_RUST_IMAGE} \
 	  -c "cd /defs/gen/pb-rust && cargo ${RUST_ACTION}"
 
-# docker already does its own caching so we can attempt a build every time
-.PHONY: docker-image
-docker-image:
-	@echo "Building base docker image"
-	cd protoc-builder && ${DOCKER_BUILD} -t ${PROTOC_IMAGE} -f Dockerfile.protoc .
+.PHONY: base-image-go
+base-image-go:
+	@echo "Building base docker image for Go"
+	cd protoc-builder && ${DOCKER_BUILD} ${DOCKER_CACHE} -t ${PROTOC_IMAGE}:go -f Dockerfile.protoc \
+	  --build-arg PROTOC_VERSION=${GO_PROTOC_VERSION} \
+	  --build-arg PROTOC_CHECKSUM=${GO_PROTOC_CHECKSUM} \
+	  --build-arg GOOGLEAPIS_COMMIT=${GO_GOOGLEAPIS_COMMIT} .
+
+.PHONY: base-image-jsonschema
+base-image-jsonschema:
+	@echo "Building base docker image for jsonschema"
+	cd protoc-builder && ${DOCKER_BUILD} ${DOCKER_CACHE} -t ${PROTOC_IMAGE}:jsonschema -f Dockerfile.protoc \
+	  --build-arg PROTOC_VERSION=${JSONSCHEMA_PROTOC_VERSION} \
+	  --build-arg PROTOC_CHECKSUM=${JSONSCHEMA_PROTOC_CHECKSUM} \
+	  --build-arg GOOGLEAPIS_COMMIT=${JSONSCHEMA_GOOGLEAPIS_COMMIT} .
+
+.PHONY: base-image-python
+base-image-python:
+	@echo "Building base docker image for Python"
+	cd protoc-builder && ${DOCKER_BUILD} ${DOCKER_CACHE} -t ${PROTOC_IMAGE}:python -f Dockerfile.protoc \
+	  --build-arg PROTOC_VERSION=${PYTHON_PROTOC_VERSION} \
+	  --build-arg PROTOC_CHECKSUM=${PYTHON_PROTOC_CHECKSUM} \
+	  --build-arg GOOGLEAPIS_COMMIT=${PYTHON_GOOGLEAPIS_COMMIT} .
+
+.PHONY: base-image-ruby
+base-image-ruby:
+	@echo "Building base docker image for Ruby"
+	cd protoc-builder && ${DOCKER_BUILD} ${DOCKER_CACHE} -t ${PROTOC_IMAGE}:ruby -f Dockerfile.protoc \
+	  --build-arg PROTOC_VERSION=${RUBY_PROTOC_VERSION} \
+	  --build-arg PROTOC_CHECKSUM=${RUBY_PROTOC_CHECKSUM} \
+	  --build-arg GOOGLEAPIS_COMMIT=${RUBY_GOOGLEAPIS_COMMIT} .
+
+.PHONY: base-image-rust
+base-image-rust:
+	@echo "Building base docker image for Rust"
+	cd protoc-builder && ${DOCKER_BUILD} ${DOCKER_CACHE} -t ${PROTOC_IMAGE}:rust -f Dockerfile.protoc \
+	  --build-arg PROTOC_VERSION=${RUST_PROTOC_VERSION} \
+	  --build-arg PROTOC_CHECKSUM=${RUST_PROTOC_CHECKSUM} \
+	  --build-arg GOOGLEAPIS_COMMIT=${RUST_GOOGLEAPIS_COMMIT} .
+
+.PHONY: base-image-typescript
+base-image-typescript:
+	@echo "Building base docker image for Typescript"
+	cd protoc-builder && ${DOCKER_BUILD} ${DOCKER_CACHE} -t ${PROTOC_IMAGE}:typescript -f Dockerfile.protoc \
+	  --build-arg PROTOC_VERSION=${TYPESCRIPT_PROTOC_VERSION} \
+	  --build-arg PROTOC_CHECKSUM=${TYPESCRIPT_PROTOC_CHECKSUM} \
+	  --build-arg GOOGLEAPIS_COMMIT=${TYPESCRIPT_GOOGLEAPIS_COMMIT} .
 
 # to recover from a situation where a stale layer exist, just  purging the
 # docker image via `make clean` is not enough. Re-building without layer
 # cache is the only solution.
-.PHONY: docker-image-no-cache
-docker-image-no-cache:
+.PHONY: base-image-no-cache
+base-image-no-cache:
 	@echo "Building development docker images with disabled cache"
-	cd protoc-builder && ${DOCKER_BUILD} -t ${PROTOC_IMAGE} -f Dockerfile.protoc .
-	cd protoc-builder && ${DOCKER_BUILD} -t ${PROTOC_GO_IMAGE} -f Dockerfile.go .
-	cd protoc-builder && ${DOCKER_BUILD} -t ${PROTOC_JSONSCHEMA_IMAGE} -f Dockerfile.jsonschema .
-	cd protoc-builder && ${DOCKER_BUILD} -t ${PROTOC_PYTHON_IMAGE} -f Dockerfile.python .
-	cd protoc-builder && ${DOCKER_BUILD} -t ${PROTOC_RUBY_IMAGE} -f Dockerfile.ruby .
-	cd protoc-builder && ${DOCKER_BUILD} -t ${PROTOC_RUST_IMAGE} -f Dockerfile.rust .
-	cd protoc-builder && ${DOCKER_BUILD} -t ${PROTOC_TYPESCRIPT_IMAGE} -f Dockerfile.typescript .
+	@DOCKER_CACHE="--no-cache" make base-image-go
+	@DOCKER_CACHE="--no-cache" make base-image-jsonschema
+	@DOCKER_CACHE="--no-cache" make base-image-python
+	@DOCKER_CACHE="--no-cache" make base-image-ruby
+	@DOCKER_CACHE="--no-cache" make base-image-rust
+	@DOCKER_CACHE="--no-cache" make base-image-typescript
 
 # clean up generated files (not working? try sudo make clean)
 clean:
@@ -111,4 +153,9 @@ clean:
 		gen/pb-python/sigstore_protobuf_specs/io \
 		gen/pb-rust/target \
 		gen/jsonschema/schemas
-	docker rmi -f ${PROTOC_IMAGE} ${PROTOC_GO_IMAGE} ${PROTOC_JSONSCHEMA_IMAGE} ${PROTOC_PYTHON_IMAGE} ${PROTOC_RUBY_IMAGE} ${PROTOC_RUST_IMAGE} ${PROTOC_TYPESCRIPT_IMAGE}
+	docker rmi -f ${PROTOC_IMAGE}:go  ${PROTOC_GO_IMAGE} \
+		      ${PROTOC_IMAGE}:jsonschema ${PROTOC_JSONSCHEMA_IMAGE} \
+		      ${PROTOC_IMAGE}:python ${PROTOC_PYTHON_IMAGE} \
+		      ${PROTOC_IMAGE}:ruby ${PROTOC_RUBY_IMAGE} \
+		      ${PROTOC_IMAGE}:rust ${PROTOC_RUST_IMAGE} \
+		      ${PROTOC_IMAGE}:typescript ${PROTOC_TYPESCRIPT_IMAGE}

--- a/protoc-builder/Dockerfile.go
+++ b/protoc-builder/Dockerfile.go
@@ -9,8 +9,8 @@ RUN cd tools && go build --trimpath google.golang.org/protobuf/cmd/protoc-gen-go
 FROM gcr.io/distroless/cc-debian12:nonroot@sha256:6970a2b2cb07c68f3e15d1b5d2ba857e53da911d5d321f48a842d6b0d26984cf
 
 COPY --from=go-builder /go/tools/protoc-* /usr/local/bin/
-COPY --from=protoc-base /protobuf/bin/protoc /usr/local/bin/
-COPY --from=protoc-base /protobuf/include/google /opt/include/google
-COPY --from=protoc-base /googleapis /googleapis
+COPY --from=protoc-base:go /protobuf/bin/protoc /usr/local/bin/
+COPY --from=protoc-base:go /protobuf/include/google /opt/include/google
+COPY --from=protoc-base:go /googleapis /googleapis
 
 ENTRYPOINT ["/usr/local/bin/protoc", "--plugin=protoc-gen-go=/usr/local/bin/protoc-gen-go", "--plugin=protoc-gen-go-grpc=/usr/local/bin/protoc-gen-go-grpc"]

--- a/protoc-builder/Dockerfile.protoc
+++ b/protoc-builder/Dockerfile.protoc
@@ -22,19 +22,17 @@ USER myuser
 
 # Download specific release of protoc
 # TODO: add dependabot-like feature to check for release updates
-ARG PROTOC_VERSION=v21.6
-ARG PROTOC_CHECKSUM=sha256:6a9fc36363a2d05d73fc363a46cd57d849068d33305db39f77daac8ba073e818
+ARG PROTOC_VERSION
+ARG PROTOC_CHECKSUM
 
 ADD --chown=myuser --checksum=${PROTOC_CHECKSUM} https://github.com/protocolbuffers/protobuf/releases/download/${PROTOC_VERSION}/protoc-${PROTOC_VERSION#v}-linux-x86_64.zip /tmp/protoc.zip
 RUN unzip -d /protobuf /tmp/protoc.zip
 RUN chmod 755 /protobuf/bin/protoc
 
 # fetch specific commit of googleapis
-# TODO: add dependabot-like feature to check for release updates
-ARG GOOGLE_APIS_VERSION=6ef9eaea379fc1cc0355e06a5a20b594543ee693
-#ARG GOOGLE_APIS_VERSION=95f0f2b2aee51e460646320d6e8f2ce75c463f5a
+ARG GOOGLEAPIS_COMMIT
 RUN git clone --filter=tree:0 https://github.com/googleapis/googleapis.git /googleapis && \
-    cd /googleapis && git checkout ${GOOGLE_APIS_VERSION}
+    cd /googleapis && git checkout ${GOOGLEAPIS_COMMIT}
 
 FROM scratch
 COPY --from=protoc-builder /protobuf /protobuf

--- a/protoc-builder/Dockerfile.python
+++ b/protoc-builder/Dockerfile.python
@@ -7,8 +7,8 @@ ADD hack/dev-requirements.txt .
 
 RUN pip3 install -r dev-requirements.txt
 
-COPY --from=protoc-base /protobuf/bin/protoc /usr/local/bin/
-COPY --from=protoc-base /protobuf/include/google /opt/include/google
-COPY --from=protoc-base /googleapis /googleapis
+COPY --from=protoc-base:python /protobuf/bin/protoc /usr/local/bin/
+COPY --from=protoc-base:python /protobuf/include/google /opt/include/google
+COPY --from=protoc-base:python /googleapis /googleapis
 
 ENTRYPOINT ["/usr/local/bin/protoc" ]

--- a/protoc-builder/Dockerfile.ruby
+++ b/protoc-builder/Dockerfile.ruby
@@ -1,7 +1,7 @@
 FROM gcr.io/distroless/cc-debian12:nonroot@sha256:6970a2b2cb07c68f3e15d1b5d2ba857e53da911d5d321f48a842d6b0d26984cf
 
-COPY --from=protoc-base /protobuf/bin/protoc /usr/local/bin/
-COPY --from=protoc-base /protobuf/include/google /opt/include/google
-COPY --from=protoc-base /googleapis /googleapis
+COPY --from=protoc-base:ruby /protobuf/bin/protoc /usr/local/bin/
+COPY --from=protoc-base:ruby /protobuf/include/google /opt/include/google
+COPY --from=protoc-base:ruby /googleapis /googleapis
 
 ENTRYPOINT [ "/usr/local/bin/protoc" ]

--- a/protoc-builder/Dockerfile.rust
+++ b/protoc-builder/Dockerfile.rust
@@ -1,8 +1,8 @@
 FROM rust:1.84.0@sha256:f7cbb35003d4ffb5543f8ad6480c1e36bbae5c3609523c9f0c2e223668ee9c1a
 
-COPY --from=protoc-base /protobuf/bin/protoc /usr/local/bin/
-COPY --from=protoc-base /protobuf/include/google /opt/include/google
-COPY --from=protoc-base /googleapis /googleapis
+COPY --from=protoc-base:rust /protobuf/bin/protoc /usr/local/bin/
+COPY --from=protoc-base:rust /protobuf/include/google /opt/include/google
+COPY --from=protoc-base:rust /googleapis /googleapis
 
 # this is not protoc because we will call Rust's prost crate to do the compilation
 ENTRYPOINT [ "/bin/bash" ]

--- a/protoc-builder/Dockerfile.typescript
+++ b/protoc-builder/Dockerfile.typescript
@@ -16,8 +16,8 @@ ENV PATH=$PATH:/nodejs/bin
 
 COPY --from=typescript-builder /app/node_modules /usr/local/lib/node_modules
 COPY --from=env-source /busybox/busybox /usr/bin/env
-COPY --from=protoc-base /protobuf/bin/protoc /usr/local/bin/
-COPY --from=protoc-base /protobuf/include/google /opt/include/google
-COPY --from=protoc-base /googleapis /googleapis
+COPY --from=protoc-base:typescript /protobuf/bin/protoc /usr/local/bin/
+COPY --from=protoc-base:typescript /protobuf/include/google /opt/include/google
+COPY --from=protoc-base:typescript /googleapis /googleapis
 
 ENTRYPOINT ["/usr/local/bin/protoc", "--plugin=/usr/local/lib/node_modules/ts-proto/protoc-gen-ts_proto" ]

--- a/protoc-builder/versions.mk
+++ b/protoc-builder/versions.mk
@@ -1,0 +1,34 @@
+# The default values for protoc version and googleapis commit will be used in the build *unless* overriden.
+#
+# If desired to override a language-specific protoc or googleapis import, 
+# set a variable with the language name prefix followed by an underscore.
+# for example:
+#
+#GO_PROTOC_VERSION=v29.3
+#GO_PROTOC_CHECKSUM=sha256:3e866620c5be27664f3d2fa2d656b5f3e09b5152b42f1bedbf427b333e90021a
+#GO_GOOGLEAPIS_COMMIT=fc2697ec5327db9073b4e0aa140248f19b15d7ef
+
+# TODO: add dependabot-like feature to check for release updates
+# release tag from https://github.com/protocolbuffers/protobuf
+DEFAULT_PROTOC_VERSION=v21.6
+
+# TODO: add dependabot-like feature to check for release updates
+# sha256 of release zip file: sha256sum protoc-${DEFAULT_PROTOC_VERSION#v}-linux-x86_64.zip | awk '{print "sha256:" $1 }'
+DEFAULT_PROTOC_CHECKSUM=sha256:6a9fc36363a2d05d73fc363a46cd57d849068d33305db39f77daac8ba073e818
+
+# TODO: add dependabot-like feature to check for release updates
+# git commit from https://github.com/googleapis/googleapis
+DEFAULT_GOOGLEAPIS_COMMIT=6ef9eaea379fc1cc0355e06a5a20b594543ee693
+
+##################################################################################
+### DO NOT EDIT BELOW THIS LINE, AS THESE VALUES ARE USED IN THE CORE MAKEFILE ###
+##################################################################################
+
+LANGUAGES := GO JSONSCHEMA PYTHON RUBY RUST TYPESCRIPT
+COMPONENTS := PROTOC_VERSION PROTOC_CHECKSUM GOOGLEAPIS_COMMIT
+
+# This is creating each possible variable permutation, e.g.
+# GO_PROTOC_VERSION, JSONSCHEMA_PROTOC_VERSION, etc
+$(foreach lang,$(LANGUAGES),\
+    $(foreach component,$(COMPONENTS),\
+        $(eval $(lang)_$(component) ?= $$(DEFAULT_$(component)))))


### PR DESCRIPTION
After looking at this a bit more, we may need the ability to independently evolve the versions of `protoc` and `googleapis/googleapis` for each language we do code generation for. This updates the Makefile and Docker build processes to use a single Dockerfile and default version, with an explicit override if necessary for a specific language.

I plan on making use of this when submitting bumps of relevant configs for each language we support in this repo, but for the sake of showing that this doesn't affect the current result of the repo, this PR should not change any generated code.