### PR TITLE
fix: dependabot typo "s/pypi/pip"

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -35,7 +35,7 @@ updates:
     directory: "/protoc-builder"
     schedule:
       interval: "monthly"
-  - package-ecosystem: "pypi"
+  - package-ecosystem: "pip"
     directory: "/protoc-builder/hack"
     schedule:
       interval: "monthly"


### PR DESCRIPTION
oops