### PR TITLE
trigger language-specific builds on protoc-builder changes

### DIFF
--- a/.github/workflows/python-build.yml
+++ b/.github/workflows/python-build.yml
@@ -23,10 +23,16 @@ on:
     paths:
       - '**.proto'
       - 'gen/pb-python/**'
+      - 'protoc-builder/Dockerfile.python'
+      - 'protoc-builder/versions.mk'
+      - 'protoc-builder/hack/dev-requirements.txt'
   pull_request:
     paths:
       - '**.proto'
       - 'gen/pb-python/**'
+      - 'protoc-builder/Dockerfile.python'
+      - 'protoc-builder/versions.mk'
+      - 'protoc-builder/hack/dev-requirements.txt'
 
 jobs:
   build:

--- a/.github/workflows/ruby-build.yml
+++ b/.github/workflows/ruby-build.yml
@@ -23,10 +23,14 @@ on:
     paths:
       - '**.proto'
       - 'gen/pb-ruby/**'
+      - 'protoc-builder/Dockerfile.ruby'
+      - 'protoc-builder/versions.mk'
   pull_request:
     paths:
       - '**.proto'
       - 'gen/pb-ruby/**'
+      - 'protoc-builder/Dockerfile.ruby'
+      - 'protoc-builder/versions.mk'
 
 jobs:
   build:

--- a/.github/workflows/rust-build.yml
+++ b/.github/workflows/rust-build.yml
@@ -23,10 +23,14 @@ on:
     paths:
       - "**.proto"
       - "gen/pb-rust/**"
+      - "protoc-builder/Dockerfile.rust"
+      - "protoc-builder/versions.mk"
   pull_request:
     paths:
       - "**.proto"
       - "gen/pb-rust/**"
+      - "protoc-builder/Dockerfile.rust"
+      - "protoc-builder/versions.mk"
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/typescript-build.yml
+++ b/.github/workflows/typescript-build.yml
@@ -23,10 +23,16 @@ on:
     paths:
       - '**.proto'
       - 'gen/pb-typescript/**'
+      - 'protoc-builder/Dockerfile.typescript'
+      - 'protoc-builder/hack/package*.json'
+      - 'protoc-builder/versions.mk'
   pull_request:
     paths:
       - '**.proto'
       - 'gen/pb-typescript/**'
+      - 'protoc-builder/Dockerfile.typescript'
+      - 'protoc-builder/hack/package*.json'
+      - 'protoc-builder/versions.mk'
 
 jobs:
   build:


### PR DESCRIPTION
ensure we get build coverage on python, rust, ruby, typescript when changes are proposed by dependabot