### PR TITLE
add automation for keeping protoc and googleapis up to date

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -47,3 +47,13 @@ updates:
     directory: "/gen/pb-rust"
     schedule:
       interval: "monthly"
+  # this monitors Homebrew builds of protobuf compiler to monitor protobuf releases;
+  # but still downloads the release asset from GitHub (since it is statically linked)
+  # the "protobuf" label triggers a workflow to update versions.mk
+  - package-ecosystem: "docker"
+    directory: "/protoc-builder/hack"
+    schedule:
+      interval: "monthly"
+    labels:
+      - "dependencies"
+      - "protobuf"

--- a/.github/workflows/googleapis-update.yml
+++ b/.github/workflows/googleapis-update.yml
@@ -1,0 +1,40 @@
+name: Update Google APIs Commit Hash
+
+on:
+  schedule:
+    - cron: '0 0 1 * *'
+  workflow_dispatch:
+
+jobs:
+  update_protobuf_version:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 0
+          persist-credentials: true
+
+      - name: Extract latest commit hash from googleapis/googleapis and create PR
+        env:
+          RUN_ID: ${{ github.run_id }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          (cd /tmp && git clone --depth=1 https://github.com/googleapis/googleapis)
+          export LATEST_COMMIT_HASH=$(cd /tmp/googleapis && git log -n 1 --format=%H)
+          sed -i "s/^\(DEFAULT_GOOGLEAPIS_COMMIT\s*=\s*\).*/\1${LATEST_COMMIT_HASH}/" protoc-builder/versions.mk
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add -A
+          git checkout -b googleapis-${RUN_ID}
+          git commit -sam "Update GOOGLEAPIS_COMMIT in versions.mk"
+          git push
+          gh pr create --title "build(deps): Bump github.com/googleapis/googleapis to latest commit" \
+            --body "This pull request updates the GOOGLEAPIS_COMMIT variable in protoc-builder/versions.mk with the latest commit hash from the googleapis/googleapis repository." \
+            --base main \
+            --head googleapis-${RUN_ID}

--- a/.github/workflows/protobuf-update.yml
+++ b/.github/workflows/protobuf-update.yml
@@ -1,0 +1,42 @@
+name: Protobuf update
+
+on:
+  pull_request:
+    types: [labeled]
+
+jobs:
+  my_job:
+    runs-on: ubuntu-latest
+    if: github.event.label.name == 'protobuf'
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 0
+          persist-credentials: true
+
+      - name: Update versions.mk with latest release version
+        id: extract_metadata
+        run: |
+          export PROTOC_VERSION="$(awk -F'[:@]' '/FROM ghcr.io\/homebrew\/core\/protobuf/{print $2; exit}' protoc-builder/hack/Dockerfile.protobuf)"
+          echo "Detected protobuf v${PROTOC_VERSION}... computing digest of artifact"
+
+          export PROTOC_ZIP=$(mktemp)
+          curl -fsSL --retry 3 -o ${PROTOC_ZIP} https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/protoc-${PROTOC_VERSION}-linux-x86_64.zip
+          export PROTOC_CHECKSUM="$(sha256sum ${PROTOC_ZIP} | awk '{print "sha256:"$1}')"
+
+          sed -i 's/^\(DEFAULT_PROTOC_VERSION\s*=\s*\).*/\1'v${PROTOC_VERSION}'/' protoc-builder/versions.mk
+          sed -i 's/^\(DEFAULT_PROTOC_CHECKSUM\s*=\s*\).*/\1'${PROTOC_CHECKSUM}'/' protoc-builder/versions.mk
+
+      - name: Amend Dependabot PR
+        env:
+          PULL_REQUEST_HEAD_REF: ${{ github.event.pull_request.head.ref }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add -A
+          git commit -sam "Bumping default protoc version and checksum in versions.mk"
+          git push origin HEAD:${PULL_REQUEST_HEAD_REF}

--- a/protoc-builder/hack/Dockerfile.protobuf
+++ b/protoc-builder/hack/Dockerfile.protobuf
@@ -1,0 +1,3 @@
+# This Dockerfile exists to allow Dependabot to watch Homebrew builds of protobuf for triggering updates
+# We don't actually use the content of this image in the repo, as this is a dynamically linked version of protoc
+FROM ghcr.io/homebrew/core/protobuf:29.3@sha256:71981a75ad707f0a75cdeb112d1db5cfb5793088abcf6131d18e49b6cff2c5f6


### PR DESCRIPTION
This creates automation to keep protoc and googleapis up to date. 

It configures dependabot to watch homebrew's build of protoc (via ghcr.io containers) to be notified of a new version being published (since that repo doesn't publish releases into any package manager).

The dependabot PR to bump the container reference will have a label added, which triggers a separate workflow to amend the PR with the correct changes to `protoc-builder/versions.mk`.

In addition, there's a monthly cron workflow that will fetch the latest commit hash from the https://github.com/googleapis/googleapis repo and update `protoc-builder/versions.mk` with it. This upstream repo doesn't use tags or cut releases at all.