### PR TITLE
address zizmor issues, remove 3p action for creating release for java

### DIFF
--- a/.github/workflows/gradle-wrapper-validation.yml
+++ b/.github/workflows/gradle-wrapper-validation.yml
@@ -7,4 +7,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - uses: gradle/wrapper-validation-action@f9c9c575b8b21b6485636a91ffecd10e558c62f6 # v3.5.0
+        with:
+          persist-credentials: false
+      - uses: gradle/actions/wrapper-validation-action@0bdd871935719febd78681f197cd39af5b6e16a6 # v4.2.2

--- a/.github/workflows/gradle-wrapper-validation.yml
+++ b/.github/workflows/gradle-wrapper-validation.yml
@@ -9,4 +9,4 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           persist-credentials: false
-      - uses: gradle/actions/wrapper-validation-action@0bdd871935719febd78681f197cd39af5b6e16a6 # v4.2.2
+      - uses: gradle/actions/wrapper-validation@0bdd871935719febd78681f197cd39af5b6e16a6 # v4.2.2

--- a/.github/workflows/java-build.yml
+++ b/.github/workflows/java-build.yml
@@ -40,6 +40,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      with:
+        persist-credentials: false
     - name: Set up JDK ${{ matrix.java-version }}
       uses: actions/setup-java@7a6d8a8234af8eb26422e24e3006232cccaa061b # v4.6.0
       with:

--- a/.github/workflows/java-release.yml
+++ b/.github/workflows/java-release.yml
@@ -4,6 +4,9 @@ on:
     tags:
       # if you change this pattern, make sure jobs.strip-tag still works
       - 'release/java/v[0-9]+.[0-9]+.[0-9]+'
+
+permissions: {}
+
 jobs:
   ci:
     uses: ./.github/workflows/java-build.yml
@@ -15,8 +18,9 @@ jobs:
     steps:
       - name: process tag
         id: version
+        env:
+          TAG: ${{ github.ref_name }}
         run: |
-          TAG=${{ github.ref_name }}
           echo "version=${TAG#"release/java/v"}" >> $GITHUB_OUTPUT
 
   build:
@@ -27,6 +31,8 @@ jobs:
     steps:
       - name: checkout tag
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
 
       - name: Set up JDK 11
         uses: actions/setup-java@7a6d8a8234af8eb26422e24e3006232cccaa061b # v4.6.0
@@ -36,10 +42,12 @@ jobs:
 
       - name: Build project
         working-directory: ./java
+        env:
+          VERSION: ${{ needs.strip-tag.outputs.version }}
         run: |
           # override the version in gradle.properties
           # we have to do some post processing with pgp signatures, cause those secrets aren't online yet
-          ./gradlew clean createReleaseBundle -Pversion=${{ needs.strip-tag.outputs.version }} -Prelease -PskipPgpSigning
+          ./gradlew clean createReleaseBundle -Pversion=${VERSION} -Prelease -PskipPgpSigning
       - name: Upload build artifacts
         uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
         with:
@@ -59,8 +67,8 @@ jobs:
           name: project-release-artifacts
           path: ./release/
       - name: Create release
-        uses: softprops/action-gh-release@c95fe1489396fe8a9eb87c0abf8aa5b2ef267fda # v2.2.1
-        with:
-          name: ${{ github.ref_name }}
-          tag_name: ${{ github.ref_name }}
-          files: ./release/*
+        env:
+          REF_NAME: ${{ github.ref_name }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create -t "${REF_NAME}" ${REF_NAME} ./release/*

--- a/.github/workflows/python-build.yml
+++ b/.github/workflows/python-build.yml
@@ -45,6 +45,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0
         with:

--- a/.github/workflows/python-release.yml
+++ b/.github/workflows/python-release.yml
@@ -14,6 +14,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      with:
+        persist-credentials: false
 
     - uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0
       with:

--- a/.github/workflows/ruby-build.yml
+++ b/.github/workflows/ruby-build.yml
@@ -50,6 +50,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
       - name: Set up Ruby ${{ matrix.python-version }}
         uses: ruby/setup-ruby@868b3f088412f139260f27f5b148179b9dd6b008 # v1.208.0
         with:

--- a/.github/workflows/ruby-release.yml
+++ b/.github/workflows/ruby-release.yml
@@ -30,6 +30,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      with:
+        persist-credentials: false
 
     - uses: ruby/setup-ruby@868b3f088412f139260f27f5b148179b9dd6b008 # v1.208.0
       with:

--- a/.github/workflows/rust-build.yml
+++ b/.github/workflows/rust-build.yml
@@ -47,6 +47,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
       - run: rustup update ${{ matrix.toolchain }} && rustup default ${{ matrix.toolchain }}
       - run: |
           make rust
@@ -62,6 +64,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
       - run: rustup update ${{ matrix.toolchain }} && rustup default ${{ matrix.toolchain }}
       - run: |
           make rust RUST_ACTION=test

--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -27,6 +27,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      with:
+        persist-credentials: false
 
     - run: RUST_ACTION='publish -p sigstore_protobuf_specs' make rust
       env:

--- a/.github/workflows/typescript-build.yml
+++ b/.github/workflows/typescript-build.yml
@@ -52,6 +52,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
       - name: Setup node ${{ matrix.node-version }}
         uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
         with:

--- a/.github/workflows/typescript-publish.yml
+++ b/.github/workflows/typescript-publish.yml
@@ -20,27 +20,28 @@ on:
 
 name: Release TypeScript package
 
-permissions:
-  contents: read
-  id-token: write
+permissions: {}
 
 jobs:
   publish:
     name: Publish package to npmjs
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     defaults:
       run:
         working-directory: gen/pb-typescript
     steps:
     - name: Checkout source
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      with:
+        persist-credentials: false
     - name: Setup node
       uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
       with:
         node-version: 18
         registry-url: 'https://registry.npmjs.org'
-        cache: npm
-        cache-dependency-path: gen/pb-typescript/package-lock.json
     - name: Build package
       run: |
         npm ci

--- a/java/README.md
+++ b/java/README.md
@@ -32,5 +32,5 @@ uploaded to a github release `release/java/v1.2.3`
 ## Why is the gradle wrapper jar checked in?
 
 The file `gradle-wrapper.jar` is usually checked into java projects that are built with gradle.
-This file is validated by the gradle/wrapper-validation-action in the java-build.yml workflow.
+This file is validated by the gradle/wrapper-validation-action in the gradle-wrapper-validation.yml workflow.
 More info at: https://github.com/gradle/wrapper-validation-action


### PR DESCRIPTION
This fixes issues reported by zizmor 🌈, as well as removing a dependency on a third-party action when the `gh` CLI should work just fine.

This also moves the gradle wrapper validation check to a non-deprecated action.

@loosebazooka @woodruffw fyi