### PR TITLE
automate publishing Java releases from GHA workflow

### DIFF
--- a/.github/workflows/java-release.yml
+++ b/.github/workflows/java-release.yml
@@ -40,6 +40,24 @@ jobs:
           java-version: 11 
           distribution: 'temurin'
 
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@dc72c7d5c4d10cd6bcb8cf6e3fd625a9e5e537da # v3.7.0
+
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@6fc4af4b145ae7821d527454aa9bd537d1f2dc5f # v0.8.1
+        with:
+          workload_identity_provider: projects/306323169285/locations/global/workloadIdentityPools/github-actions-pool/providers/github-actions-provider
+          service_account: protobuf-specs-releaser@sigstore-secrets.iam.gserviceaccount.com
+
+      - uses: google-github-actions/get-secretmanager-secrets@e5bb06c2ca53b244f978d33348d18317a7f263ce # v2.2.2
+        id: secrets
+        with:
+          secrets: |-
+            signing_key:sigstore-secrets/sigstore-java-pgp-priv-key
+            signing_password:sigstore-secrets/sigstore-java-pgp-priv-key-password
+            sonatype_username:sigstore-secrets/sigstore-java-sonatype-username
+            sonatype_password:sigstore-secrets/sigstore-java-sonatype-password
+
       - name: Build project
         working-directory: ./java
         env:


### PR DESCRIPTION
@loosebazooka can you add commits to this PR to fully switch over to publishing through the workflow instead of a manual run of the script?
