### PR TITLE
script to move publish tokens to GCP secret manager

### DIFF
--- a/.github/workflows/migrate-secrets.yml
+++ b/.github/workflows/migrate-secrets.yml
@@ -1,0 +1,37 @@
+name: Store Publish Tokens in GCP Secret Manager
+
+on:
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  store-secrets:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@6fc4af4b145ae7821d527454aa9bd537d1f2dc5f # v0.8.1
+        with:
+          workload_identity_provider: projects/306323169285/locations/global/workloadIdentityPools/github-actions-pool/providers/github-actions-provider
+          service_account: protobuf-specs-releaser@sigstore-secrets.iam.gserviceaccount.com
+
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@6189d56e4096ee891640bb02ac264be376592d6a # v2.1.2
+        with:
+          project_id: 'sigstore-secrets'
+
+      - name: Store secrets in Secret Manager
+        env:
+          NPM_PUBLISH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+          RUBYGEMS_AUTH_TOKEN: ${{ secrets.RUBYGEMS_AUTH_TOKEN }}
+        run: |
+          printenv NPM_PUBLISH_TOKEN | gcloud secrets create protobuf-specs-npm-publish-token --replication-policy="automatic" --data-file=-
+
+          printenv CARGO_REGISTRY_TOKEN | gcloud secrets create protobuf-specs-cargo-registry-token --replication-policy="automatic" --data-file=-
+
+          printenv RUBYGEMS_AUTH_TOKEN | gcloud secrets create protobuf-specs-rubygems-auth-token --replication-policy="automatic" --data-file=-


### PR DESCRIPTION
this should be a one time script to read our publish tokens out of GitHub Actions secrets and copy them into GCP secret manager

once this is run successfully, I'll update the release flows to read from secret manager and delete the secrets from the repo

this gives oncall more explicit control of our tokens and an audit log