### PR TITLE
don't run the code gen test twice on PRs

### DIFF
--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -20,6 +20,8 @@ permissions:
 
 on:
   push:
+    branches:
+      - 'main'
     paths:
       - '**.proto'
       - 'gen/**'


### PR DESCRIPTION
without this we're running the code gen test twice on dependabot PRs because its a push to a local branch AND a PR.