### PR TITLE
Create container-release.yml

### DIFF
--- a/.github/workflows/container-release.yml
+++ b/.github/workflows/container-release.yml
@@ -1,0 +1,68 @@
+#
+# Copyright 2025 The Sigstore Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+name: Release Services Build Container
+
+on:
+  push:
+    tags:
+    - 'v*'
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+
+    permissions:
+      id-token: write
+      contents: read
+      packages: write
+      attestations: write
+
+    env:
+      REGISTRY: ghcr.io
+      IMAGE_NO_TAG: ghcr.io/${{ github.repository }}-service-builder
+      IMAGE_REF: ghcr.io/${{ github.repository }}-service-builder:${{ github.ref_name }}
+
+    steps:
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+    
+    - name: Log into ghcr.io
+      uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
+      with:
+        registry: ${{ env.REGISTRY }}
+        username: ${{ github.repository_owner }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Build services container
+      run: make services-image
+
+    - name: Tag image
+      run: docker tag protoc-services ${{ env.IMAGE_REF }}
+
+    - name: Push image
+      run: docker push ${{ env.IMAGE_REF }}
+
+    - name: Get image digest
+      run: |
+        digest=$(docker inspect --format='{{index .RepoDigests 0}}' ${{ env.IMAGE_REF }})
+        image_digest=$(echo $digest | cut -d"@" -f2)
+        echo "IMAGE_DIGEST=$image_digest" >> "$GITHUB_ENV"
+
+    - name: Generate artifact attestation
+      uses: actions/attest-build-provenance@db473fddc028af60658334401dc6fa3ffd8669fd # v2.3.0
+      with:
+        subject-name: ${{ env.IMAGE_NO_TAG }}
+        subject-digest: ${{ env.IMAGE_DIGEST }}
+        push-to-registry: true
+        

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,9 @@ PROTOC_JSONSCHEMA_IMAGE = protoc-jsonschema
 PROTOC_PYTHON_IMAGE = protoc-python
 PROTOC_RUBY_IMAGE = protoc-ruby
 PROTOC_RUST_IMAGE = protoc-rust
-PROTOC_SERVICES_IMAGE = protoc-services
+# the container release action depends on the name being "protoc-services"
+# so change it there too if you change it here.
+PROTOC_SERVICES_IMAGE = protoc-services 
 PROTOC_TYPESCRIPT_IMAGE = protoc-typescript
 
 RUST_ACTION ?= run -p sigstore-protobuf-specs-codegen


### PR DESCRIPTION
#### Summary
On tagging a release, will create a container at ghcr.io/sigstore/protobuf-specs-services-builder:<tag> and attach an attestation to it.

#### Release Note

#### Documentation
