### PR TITLE
Release container builder from its own tag

### DIFF
--- a/.github/workflows/container-release.yml
+++ b/.github/workflows/container-release.yml
@@ -12,12 +12,12 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-name: Release Services Build Container
+name: Release service builder container
 
 on:
   push:
     tags:
-    - 'v*'
+    - 'release/service-builder/v*'
 
 jobs:
   release:


### PR DESCRIPTION
#### Summary
Prevent re-tagging on failure over go-tags which would cause proxy issues

#### Release Note

#### Documentation
