### PR TITLE
export rekor types from pb-typescript

### DIFF
--- a/gen/pb-typescript/package-lock.json
+++ b/gen/pb-typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sigstore/protobuf-specs",
-  "version": "0.4.0",
+  "version": "0.4.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@sigstore/protobuf-specs",
-      "version": "0.4.0",
+      "version": "0.4.3",
       "license": "Apache-2.0",
       "devDependencies": {
         "@tsconfig/node18": "^18.2.4",

--- a/gen/pb-typescript/package.json
+++ b/gen/pb-typescript/package.json
@@ -4,6 +4,10 @@
   "description": "code-signing for npm packages",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
+  "exports": {
+    ".": "./dist/index.js",
+    "./rekor/v2": "./dist/rekor/v2/index.js"
+  },
   "scripts": {
     "build": "tsc"
   },

--- a/gen/pb-typescript/src/rekor/v2/index.ts
+++ b/gen/pb-typescript/src/rekor/v2/index.ts
@@ -1,0 +1,19 @@
+/*
+Copyright 2025 The Sigstore Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+export * from '../../__generated__/rekor/v2/dsse';
+export * from '../../__generated__/rekor/v2/entry';
+export * from '../../__generated__/rekor/v2/hashedrekord';
+export * from '../../__generated__/rekor/v2/verifier';


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
Updates the generated `@sigstore/protobuf-specs` npm package to export the Rekor v2 types added in #661.

