### PR TITLE
update release instructions for typescript

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -62,6 +62,8 @@ Checklist prior to releasing:
    `version` matches the targeted release.
 1. Update [package.json](gen/pb-typescript/package.json) so the
     `version` matches the targeted release.
+    - Run `npm install` from the "gen/pb-typescript" directory to sync the
+     version change to the `package-lock.json` file.
 1. Update [version.rb](gen/pb-ruby/lib/sigstore_protobuf_specs/version.rb) so the
    `version` matches the targeted release.
 1. Update [Cargo.toml](gen/pb-rust/Cargo.toml) so the


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
Updates the TypeScript release instructions to include a step to regenerate the `package-lock.json` file. This will ensure that the version in `package-lock.json` file matches the `package.json`.