### PR TITLE
move rust release to use trusted publishing

### DIFF
--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -35,18 +35,9 @@ jobs:
       with:
         persist-credentials: false
 
-    - name: Authenticate to Google Cloud
-      uses: google-github-actions/auth@ba79af03959ebeac9769e648f473a284504d9193 # v2.1.10
-      with:
-        workload_identity_provider: projects/306323169285/locations/global/workloadIdentityPools/github-actions-pool/providers/github-actions-provider
-        service_account: protobuf-specs-releaser@sigstore-secrets.iam.gserviceaccount.com
-
-    - uses: google-github-actions/get-secretmanager-secrets@a8440875e1c2892062aef9061228d4f1af8f919b # v2.2.3
-      id: secrets
-      with:
-        secrets: |-
-          cargo_registry_token:sigstore-secrets/protobuf-specs-cargo-registry-token
+    - uses: rust-lang/crates-io-auth-action@e919bc7605cde86df457cf5b93c5e103838bd879 # v1.0.1
+      id: auth
 
     - run: RUST_ACTION='publish -p sigstore_protobuf_specs' make rust
       env:
-        CARGO_REGISTRY_TOKEN: "${{ steps.secrets.outputs.cargo_registry_token }}"
+        CARGO_REGISTRY_TOKEN: "${{ steps.auth.outputs.token }}"


### PR DESCRIPTION
https://crates.io/docs/trusted-publishing is live, so switching over to it