### PR TITLE
move to trixie from bullseye

### DIFF
--- a/protoc-builder/Dockerfile.protoc
+++ b/protoc-builder/Dockerfile.protoc
@@ -2,7 +2,7 @@
 # This container grabs the protoc compiler and the googleapi includes
 # /protobuf will contain the extracted protoc
 # /googleapis will contain the various googleapis proto imports one might need
-FROM debian:bullseye-slim@sha256:b5f9bc44bdfbd9d551dfdd432607cbc6bb5d9d6dea726a1191797d7749166973 AS protoc-builder
+FROM debian:trixie-slim@sha256:c85a2732e97694ea77237c61304b3bb410e0e961dd6ee945997a06c788c545bb AS protoc-builder
 
 # Create output directories
 RUN mkdir /protobuf /googleapis


### PR DESCRIPTION
shouldn't have any effect on codegen, just uses more up to date versions of utilities